### PR TITLE
simplify proof params

### DIFF
--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -4,7 +4,6 @@
     #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #endif
 
-#define DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #include "doctest.h"
 
 #include <assert.h>


### PR DESCRIPTION
compute implied values in `ProofParams` rather than storing them