### PR TITLE
shrink CI build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,10 @@ jobs:
             mode: Release
             compiler: clang
             toolchain: default
+          - os: ubuntu-24.04
+            mode: Release
+            compiler: clang
+            toolchain: ubsan
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/ubsan.cmake
+++ b/ubsan.cmake
@@ -1,2 +1,8 @@
 set(CMAKE_C_FLAGS_INIT "-fsanitize=undefined -fno-sanitize-recover=all")
 set(CMAKE_CXX_FLAGS_INIT "-fsanitize=undefined -fno-sanitize-recover=all")
+
+# only clang supports type sanitizer
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+set(CMAKE_C_FLAGS_INIT "-fsanitize=memory -fsanitize=type ${CMAKE_C_FLAGS_INIT}")
+set(CMAKE_CXX_FLAGS_INIT "-fsanitize=memory -fsanitize=type ${CMAKE_CXX_FLAGS_INIT}")
+endif()


### PR DESCRIPTION
Our build matrix is a bit bigger than it needs to be. Not every dimension needs to be fully covered. This makes sure we test on clang on ubuntu, and runs the sanitizers on mac and ubuntu, but not combined with every other build property.