### PR TITLE
missing `readPlotFileIfNeeded()`

### DIFF
--- a/src/prove/Prover.hpp
+++ b/src/prove/Prover.hpp
@@ -467,6 +467,8 @@ public:
 
     std::vector<uint64_t> getAllProofFragmentsForProof(QualityChain const& chain)
     {
+        readPlotFileIfNeeded();
+
         std::vector<uint64_t> proof_fragments;
         #ifdef DEBUG_CHAINING
         std::cout << "Getting all proof fragments for chain with " << chain.chain_links.size() << " links." << std::endl;


### PR DESCRIPTION
if `getAllProofFragmentsForProof()` is the first function to be called on `Prover`, it currently fails with a bad optional access.