### PR TITLE
Do not override windows runtime lib on `fse` target

### DIFF
--- a/lib/fse/CMakeLists.txt
+++ b/lib/fse/CMakeLists.txt
@@ -57,7 +57,6 @@ target_compile_options(fse PRIVATE
       /Oy
       /GL
       /D
-      /MT
       /Zi
     >
     $<$<CONFIG:Debug>:
@@ -65,7 +64,6 @@ target_compile_options(fse PRIVATE
       /Od
       /we
       /RTC1
-      /MDd
       /Zi
     >
   >


### PR DESCRIPTION
Direct porting from the official `libfse.vcxproj` compiler cli output used fixed runtime libraries for on windows. This removes it from the compiler options and uses whatever is set in the cmake project.