### PR TITLE
Add macOS 13-intel to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
           - macos-14
           - macos-15
           - macos-15-intel
+          - macos-13-intel
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-22.04-arm


### PR DESCRIPTION
expected to fail - for science