### PR TITLE
enable AES hardware acceleration in rust crate

### DIFF
--- a/crates/chia-pos2/build.rs
+++ b/crates/chia-pos2/build.rs
@@ -1,3 +1,25 @@
+/// Match `src/CMakeLists.txt` `pos2_base` flags so `intrin_portable.h` sees
+/// `__AES__` / `__CRYPTO__` and sets `HAVE_AES`.
+fn apply_hw_aes_flags(build: &mut cc::Build) {
+    let Ok(arch) = std::env::var("CARGO_CFG_TARGET_ARCH") else {
+        return;
+    };
+    let target = std::env::var("TARGET").unwrap_or_default();
+    let is_msvc = target.contains("msvc");
+
+    match arch.as_str() {
+        // x86_64: GCC/Clang need `-maes` (CMake: GNU|Clang only). MSVC gets AES via intrin_portable.h.
+        "x86_64" if !is_msvc => {
+            build.flag_if_supported("-maes");
+        }
+        // 64-bit ARM: enable crypto extensions (e.g. Raspberry Pi 5).
+        "aarch64" => {
+            build.flag_if_supported("-march=armv8-a+crypto");
+        }
+        _ => {}
+    }
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=../../src");
 
@@ -10,6 +32,7 @@ fn main() {
         .include("cpp")
         .include("fse/fse")
         .file("cpp/api.cpp");
+    apply_hw_aes_flags(&mut build);
 
     let is_fuzzing = std::env::var("CARGO_CFG_FUZZING").is_ok();
     let is_debug_build = std::env::var_os("OPT_LEVEL").unwrap_or("".into()) == "0";


### PR DESCRIPTION
the version of this code we use in `chia-blockchain` is built by `cargo`, which currently doesn't set the build flags to enable AES hardware acceleration. This PR fixes that.