### PR TITLE
support separating testnet plots and mainnet plots

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -54,11 +54,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
+      - name: Test (release)
+        run: cargo test --all --release --all-features -- --include-ignored
+
       - name: Test (debug)
         run: cargo test --all --all-features
-
-      - name: Test (release)
-        run: cargo test --all --release --all-features
 
 
   fuzz_tests:

--- a/crates/chia-pos2-tools/src/bin/test-prover.rs
+++ b/crates/chia-pos2-tools/src/bin/test-prover.rs
@@ -19,6 +19,10 @@ struct Args {
     /// Disable solving and validating proofs
     #[arg(long, default_value_t = false)]
     disable_solving: bool,
+
+    /// Use testnet proof parameters (plot filename is suffixed to avoid clashing with mainnet)
+    #[arg(long, default_value_t = false)]
+    testnet: bool,
 }
 
 fn main() {
@@ -30,7 +34,11 @@ fn main() {
     let strength = 2;
     let index = 0;
     let meta_group = 0;
-    let plot_filename = format!("k-18-test-{}.plot2", hex::encode(plot_id));
+    let plot_filename = format!(
+        "k-18-test-{}{}.plot2",
+        hex::encode(plot_id),
+        if args.testnet { "_testnet" } else { "" }
+    );
     let plot_filename = Path::new(&plot_filename);
     if !exists(plot_filename).expect("exists failed") {
         println!("generating plot: {}", plot_filename.display());
@@ -42,6 +50,7 @@ fn main() {
             index,
             meta_group,
             &[32; 64 + 48],
+            args.testnet,
         )
         .expect("create_v2_plot");
     }
@@ -66,11 +75,12 @@ fn main() {
             // We pretend the qualities pass just to exercise more partial
             // proofs
             if !args.disable_solving {
-                let full_proof = solve_proof(&q, &plot_id, k, strength);
+                let full_proof = solve_proof(&q, &plot_id, k, strength, args.testnet);
                 // we expect the proof to be valid
                 assert!(!full_proof.is_empty());
                 assert!(
-                    validate_proof_v2(&plot_id, k, &challenge, strength, &full_proof).is_some()
+                    validate_proof_v2(&plot_id, k, &challenge, strength, &full_proof, args.testnet)
+                        .is_some()
                 );
             }
         }

--- a/crates/chia-pos2/fuzz/fuzz_targets/prover.rs
+++ b/crates/chia-pos2/fuzz/fuzz_targets/prover.rs
@@ -29,6 +29,7 @@ fn create_test_plots() {
                 index,
                 meta_group,
                 &memo,
+                false,
             )
             .expect("create_v2_plot()");
         }
@@ -48,8 +49,8 @@ fuzz_target!(init: { create_test_plots(); }, |challenge: Bytes32| {
         let k = plot.size();
         for quality in qualities {
             let _ = serialize_quality(&quality.chain_links, strength);
-            let proof = solve_proof(&quality, plot_id, k, strength);
-            assert!(validate_proof_v2(plot_id, k, &challenge, strength, &proof).is_some());
+            let proof = solve_proof(&quality, plot_id, k, strength, false);
+            assert!(validate_proof_v2(plot_id, k, &challenge, strength, &proof, false).is_some());
         }
     }
 });

--- a/crates/chia-pos2/fuzz/fuzz_targets/solver.rs
+++ b/crates/chia-pos2/fuzz/fuzz_targets/solver.rs
@@ -19,6 +19,6 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     let Ok(quality) = QualityChain::arbitrary(&mut unstructured) else {
         return Corpus::Reject;
     };
-    let _ = solve_proof(&quality, &plot_id, k_size, strength);
+    let _ = solve_proof(&quality, &plot_id, k_size, strength, false);
     Corpus::Keep
 });

--- a/crates/chia-pos2/fuzz/fuzz_targets/validate.rs
+++ b/crates/chia-pos2/fuzz/fuzz_targets/validate.rs
@@ -22,7 +22,10 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     let Ok(proof) = Vec::<u8>::arbitrary(&mut unstructured) else {
         return Corpus::Reject;
     };
+    let Ok(testnet) = bool::arbitrary(&mut unstructured) else {
+        return Corpus::Reject;
+    };
 
-    let _ = validate_proof_v2(&plot_id, k_size, &challenge, strength, &proof);
+    let _ = validate_proof_v2(&plot_id, k_size, &challenge, strength, &proof, testnet);
     Corpus::Keep
 });

--- a/crates/chia-pos2/src/lib.rs
+++ b/crates/chia-pos2/src/lib.rs
@@ -27,6 +27,7 @@ unsafe extern "C" {
         strength: u8,
         challenge: *const u8,
         proof: *const u32,
+        testnet: u8,
         quality: *mut QualityChain,
     ) -> bool;
 
@@ -45,6 +46,7 @@ unsafe extern "C" {
         plot_id: *const u8,
         k: u8,
         strength: u8,
+        testnet: u8,
         output: *mut u32,
     ) -> bool;
 
@@ -57,6 +59,7 @@ unsafe extern "C" {
         k: u8,
         strength: u8,
         proof: *const u32,
+        testnet: u8,
         quality: *mut QualityChain,
     ) -> bool;
 
@@ -69,16 +72,19 @@ unsafe extern "C" {
         meta_group: u8,
         memo: *const u8,
         memo_length: u8,
+        testnet: u8,
     ) -> bool;
 }
 
 pub type Bytes32 = [u8; 32];
 
+/// `testnet` must match the network used to create the plot and to validate proofs.
 pub fn solve_proof(
     quality_proof: &QualityChain,
     plot_id: &Bytes32,
     k: u8,
     strength: u8,
+    testnet: bool,
 ) -> Vec<u8> {
     let mut proof = [0_u32; 128];
     // SAFETY: Calling into pos2 C++ library. See src/api.cpp for requirements
@@ -91,6 +97,7 @@ pub fn solve_proof(
             plot_id.as_ptr(),
             k,
             strength,
+            u8::from(testnet),
             proof.as_mut_ptr(),
         )
     } {
@@ -100,12 +107,14 @@ pub fn solve_proof(
     bits::compact_bits(&proof, k)
 }
 
+/// `testnet`: use `true` for testnet plot parameters, `false` for mainnet.
 pub fn validate_proof_v2(
     plot_id: &Bytes32,
     size: u8,
     challenge: &Bytes32,
     strength: u8,
     proof: &[u8],
+    testnet: bool,
 ) -> Option<QualityChain> {
     let x_values = bits::expand_bits(proof, size)?;
 
@@ -126,6 +135,7 @@ pub fn validate_proof_v2(
             strength,
             challenge.as_ptr(),
             x_values.as_ptr(),
+            u8::from(testnet),
             &mut quality,
         )
     };
@@ -134,11 +144,13 @@ pub fn validate_proof_v2(
 
 /// Converts full proof bytes to quality string (does not validate the proof).
 /// Returns `Some(quality)` on success, `None` if proof format is invalid or conversion fails.
+/// `testnet` must match the network used when the proof was produced.
 pub fn quality_string_from_proof(
     plot_id: &Bytes32,
     k: u8,
     strength: u8,
     proof: &[u8],
+    testnet: bool,
 ) -> Option<QualityChain> {
     let x_values = bits::expand_bits(proof, k)?;
 
@@ -155,12 +167,15 @@ pub fn quality_string_from_proof(
             k,
             strength,
             x_values.as_ptr(),
+            u8::from(testnet),
             &mut quality,
         )
     };
     if ok { Some(quality) } else { None }
 }
 
+/// `testnet`: use `true` to create a plot with testnet parameters (not valid on mainnet).
+#[allow(clippy::too_many_arguments)]
 pub fn create_v2_plot(
     filename: &Path,
     k: u8,
@@ -169,6 +184,7 @@ pub fn create_v2_plot(
     index: u16,
     meta_group: u8,
     memo: &[u8],
+    testnet: bool,
 ) -> Result<()> {
     let Some(filename) = filename.to_str() else {
         return Err(Error::other("invalid path"));
@@ -197,6 +213,7 @@ pub fn create_v2_plot(
             meta_group,
             memo.as_ptr(),
             memo.len() as u8,
+            u8::from(testnet),
         )
     };
     if success {
@@ -366,29 +383,48 @@ mod tests {
 
     /// Creates a v2 plot if missing, runs 100 challenges, solves proofs, validates,
     /// and round-trips proof -> quality_string and checks it matches the original quality.
-    #[test]
-    fn test_plot_roundtrip() {
+    /// Matrix: 2×2×2 (testnet × plot index × meta group) = 8 cases.
+    /// Expected proof totals are defined in `expected_proof_count` below; update them if the
+    /// challenge loop range or plot parameters change.
+    #[rstest]
+    /// This test is expensive to run in un-optimized mode. To run this test:
+    /// cargo test --release -- --include-ignored
+    #[ignore]
+    fn test_plot_roundtrip(
+        #[values(false, true)] testnet: bool,
+        #[values(0u16, 3u16)] index: u16,
+        #[values(0u8, 7u8)] meta_group: u8,
+    ) {
         let k = 20u8;
         let strength = 2u8;
-        let index = 0u16;
-        let meta_group = 0u8;
-        let plot_id: Bytes32 = [0xab; 32];
+        let mut plot_id = [0xabu8; 32];
+        plot_id[0..2].copy_from_slice(&index.to_le_bytes());
+        plot_id[2] = meta_group;
+
         let memo = [0u8; 112];
-        let plot_path = std::env::temp_dir().join("pos2_chia_test_k20.plot");
+        let plot_name = format!(
+            "pos2_chia_test_k20_i{index}_g{meta_group}{}.plot",
+            if testnet { "_testnet" } else { "" }
+        );
+        let plot_path = std::env::temp_dir().join(plot_name);
 
         if !plot_path.exists() {
-            create_v2_plot(&plot_path, k, strength, &plot_id, index, meta_group, &memo)
-                .expect("create_v2_plot");
+            create_v2_plot(
+                &plot_path, k, strength, &plot_id, index, meta_group, &memo, testnet,
+            )
+            .expect("create_v2_plot");
         }
 
         let prover = Prover::new(&plot_path).expect("open prover");
         assert_eq!(prover.size(), k);
         assert_eq!(prover.get_strength(), strength);
+        assert_eq!(prover.get_plot_index(), index);
+        assert_eq!(prover.get_meta_group(), meta_group);
         let plot_id = *prover.plot_id();
 
         let mut num_proofs = 0;
         let mut challenge = [0u8; 32];
-        for challenge_idx in 0..300u32 {
+        for challenge_idx in 0..100u32 {
             challenge[0..4].copy_from_slice(&challenge_idx.to_le_bytes());
 
             let qualities = prover
@@ -396,15 +432,19 @@ mod tests {
                 .expect("get_qualities_for_challenge");
 
             for quality in qualities {
-                let proof = solve_proof(&quality, &plot_id, k, strength);
+                let proof = solve_proof(&quality, &plot_id, k, strength, testnet);
                 assert!(!proof.is_empty(), "failed to solve proof");
                 num_proofs += 1;
-                let validated = validate_proof_v2(&plot_id, k, &challenge, strength, &proof);
                 assert!(
-                    validated.is_some(),
-                    "proof should validate for challenge {challenge_idx}",
+                    validate_proof_v2(&plot_id, k, &challenge, strength, &proof, testnet).is_some(),
+                    "proof should validate for challenge {challenge_idx} (testnet={testnet} index={index} meta_group={meta_group})",
                 );
-                let recovered = quality_string_from_proof(&plot_id, k, strength, &proof);
+                assert!(
+                    validate_proof_v2(&plot_id, k, &challenge, strength, &proof, !testnet)
+                        .is_none(),
+                    "proof must not validate under opposite network flag (challenge {challenge_idx}, testnet={testnet})",
+                );
+                let recovered = quality_string_from_proof(&plot_id, k, strength, &proof, testnet);
                 let recovered = recovered.expect("quality_string_from_proof");
                 assert_eq!(
                     quality.chain_links, recovered.chain_links,
@@ -412,7 +452,27 @@ mod tests {
                 );
             }
         }
-        assert_eq!(num_proofs, 539);
+        let expected = expected_proof_count(testnet, index, meta_group);
+        assert_eq!(
+            num_proofs, expected,
+            "testnet={testnet} index={index} meta_group={meta_group}",
+        );
+    }
+
+    /// Expected number of qualities (proofs) found over 100 challenges for each test matrix case.
+    /// Tallies over **100** sequential challenges (`challenge_idx` 0..100).
+    fn expected_proof_count(testnet: bool, index: u16, meta_group: u8) -> u32 {
+        match (testnet, index, meta_group) {
+            (false, 0, 0) => 160,
+            (false, 0, 7) => 168,
+            (false, 3, 0) => 187,
+            (false, 3, 7) => 221,
+            (true, 0, 0) => 143,
+            (true, 0, 7) => 187,
+            (true, 3, 0) => 164,
+            (true, 3, 7) => 190,
+            _ => unreachable!("test matrix is fixed to 8 cases"),
+        }
     }
 
     #[rstest]

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -16,6 +16,7 @@ bool validate_proof(uint8_t const* plot_id,
     uint8_t const strength,
     uint8_t const* challenge,
     uint32_t const* proof,
+    uint8_t const testnet,
     QualityChain* quality)
 try {
     if ((k_size & 1) != 0 || k_size < 18 || k_size > 32)
@@ -24,7 +25,7 @@ try {
         return false;
     if (plot_id == nullptr || challenge == nullptr || proof == nullptr || quality == nullptr)
         return false;
-    ProofParams const params(plot_id, k_size, strength);
+    ProofParams const params(plot_id, k_size, strength, testnet);
     ProofValidator validator(params);
     std::optional<QualityChainLinks> quality_links = validator.validate_full_proof(
         std::span<uint32_t const, TOTAL_XS_IN_PROOF>(proof, proof + TOTAL_XS_IN_PROOF),
@@ -72,6 +73,7 @@ bool proof_to_quality_string(uint8_t const* plot_id,
     uint8_t const k,
     uint8_t const strength,
     uint32_t const* proof,
+    uint8_t const testnet,
     QualityChain* quality)
 try {
     if ((k & 1) != 0 || k < 18 || k > 32)
@@ -80,7 +82,7 @@ try {
         return false;
     if (plot_id == nullptr || proof == nullptr || quality == nullptr)
         return false;
-    ProofParams params(plot_id, k, strength);
+    ProofParams params(plot_id, k, strength, testnet);
     ProofFragmentCodec codec(params);
     quality->chain_links = codec.fullProofXValuesToQualityString(
         std::span<uint32_t const, TOTAL_XS_IN_PROOF>(proof, proof + TOTAL_XS_IN_PROOF));
@@ -96,6 +98,7 @@ bool solve_partial_proof(QualityChain const* quality,
     uint8_t const* plot_id,
     uint8_t const k,
     uint8_t const strength,
+    uint8_t const testnet,
     uint32_t* output)
 try {
     if ((k & 1) != 0 || k < 18 || k > 32)
@@ -104,7 +107,7 @@ try {
         return false;
     if (quality == nullptr || plot_id == nullptr || output == nullptr)
         return false;
-    ProofParams params(plot_id, k, strength);
+    ProofParams params(plot_id, k, strength, testnet);
     ProofFragmentCodec c(params);
 
     std::array<uint32_t, TOTAL_T1_PAIRS_IN_PROOF> x_bits;
@@ -143,7 +146,8 @@ bool create_plot(char const* filename,
     uint16_t const index,
     uint8_t const meta_group,
     uint8_t const* memo,
-    uint8_t const memo_length)
+    uint8_t const memo_length,
+    uint8_t const testnet)
 try {
     if ((k & 1) != 0 || k < 18 || k > 32)
         return false;
@@ -153,7 +157,7 @@ try {
         return false;
     if (memo_length == 0)
         return false;
-    ProofParams params(plot_id, int(k), int(strength));
+    ProofParams params(plot_id, int(k), int(strength), testnet);
     Plotter plotter(params);
     PlotData plot = plotter.run();
     PlotFile::writeData(filename,

--- a/src/plot/PlotFile.hpp
+++ b/src/plot/PlotFile.hpp
@@ -193,7 +193,7 @@ public:
         uint8_t meta_group;
         in.read(reinterpret_cast<char*>(&meta_group), sizeof(meta_group));
 
-        ProofParams params(plot_id_bytes, k, strength);
+        ProofParams params(plot_id_bytes, k, strength, 0);
 
         uint8_t memo_length = 0;
         in.read(reinterpret_cast<char*>(&memo_length), sizeof(memo_length));

--- a/src/pos/ProofParams.hpp
+++ b/src/pos/ProofParams.hpp
@@ -28,7 +28,7 @@ public:
     ProofParams(uint8_t const* const plot_id_bytes,
         uint8_t const k,
         uint8_t const strength,
-        uint8_t const testnet = 0)
+        uint8_t const testnet)
         : k_(k)
         , strength_(strength)
         , testnet_(testnet)

--- a/src/tools/analytics/DiskBench.hpp
+++ b/src/tools/analytics/DiskBench.hpp
@@ -185,7 +185,7 @@ public:
             = "5c00000000000000000000000000000000000000000000000000000000000000";
         std::array<uint8_t, 32> challenge = Utils::hexToBytes(challenge_hex);
         uint32_t sim_challenge_id = 0;
-        ProofParams proof_params(Utils::hexToBytes(plot_id_hex).data(), k, 2);
+        ProofParams proof_params(Utils::hexToBytes(plot_id_hex).data(), k, 2, 0);
         ProofCore proof_core(proof_params);
         Timer timer;
         double total_harvesting_compute_time_ms = 0.0;

--- a/src/tools/analytics/analytics_main.cpp
+++ b/src/tools/analytics/analytics_main.cpp
@@ -172,7 +172,8 @@ try {
             Utils::hexToBytes("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")
                 .data(),
             28,
-            2);
+            2,
+            0);
         DiskBench diskbench(proof_params);
         diskbench.simulateChallengeDiskReads(
             plotIdFilter, plotsInGroup, diskTB, diskSeekMs, diskReadMBs);

--- a/src/tools/prover/prover_main.cpp
+++ b/src/tools/prover/prover_main.cpp
@@ -97,7 +97,7 @@ try {
         std::array<uint8_t, 32> plot_id = Utils::hexToBytes(plot_id_hex);
         std::array<uint8_t, 32> challenge = Utils::hexToBytes(challenge_hex);
         ProofParams params(
-            plot_id.data(), numeric_cast<uint8_t>(k), numeric_cast<uint8_t>(plot_strength));
+            plot_id.data(), numeric_cast<uint8_t>(k), numeric_cast<uint8_t>(plot_strength), 0);
         ProofValidator proof_validator(params);
 
         std::vector<uint32_t> proof = Utils::compressedHexToKValues(k, proof_hex);

--- a/src/tools/solver/solver_main.cpp
+++ b/src/tools/solver/solver_main.cpp
@@ -22,7 +22,7 @@ int benchmark(uint8_t k, uint8_t plot_strength)
 
     std::cout << "Running benchmark for:" << std::endl;
 
-    ProofParams params(plot_id.data(), k, plot_strength);
+    ProofParams params(plot_id.data(), k, plot_strength, 0);
     params.show();
 
     Solver solver(params);
@@ -53,7 +53,7 @@ int xbits(std::string const& plot_id_hex,
 {
     // convert plot_id_hex to bytes
     std::array<uint8_t, 32> plot_id = Utils::hexToBytes(plot_id_hex);
-    ProofParams params(plot_id.data(), k, strength);
+    ProofParams params(plot_id.data(), k, strength, 0);
 
     params.show();
 

--- a/tests/test_chainer.cpp
+++ b/tests/test_chainer.cpp
@@ -22,7 +22,7 @@ TEST_CASE("small_lists")
     std::string plot_id_hex = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
     std::string challenge_hex = "5c00000000000000000000000000000000000000000000000000000000000000";
     std::array<uint8_t, 32> challenge = Utils::hexToBytes(challenge_hex);
-    ProofParams proof_params(Utils::hexToBytes(plot_id_hex).data(), k, 2);
+    ProofParams proof_params(Utils::hexToBytes(plot_id_hex).data(), k, 2, 0);
     ProofCore proof_core(proof_params);
 
     ProofCore::SelectedChallengeSets selected_sets = proof_core.selectChallengeSets(challenge);

--- a/tests/test_plot_file.cpp
+++ b/tests/test_plot_file.cpp
@@ -16,7 +16,7 @@ TEST_CASE("plot-read-write")
     Timer timer {};
     timer.start("");
 
-    ProofParams params(Utils::hexToBytes(PLOT_ID_HEX).data(), K, strength);
+    ProofParams params(Utils::hexToBytes(PLOT_ID_HEX).data(), K, strength, 0);
     Plotter plotter(params);
     PlotData plot = plotter.run();
     timer.stop();

--- a/tests/test_solver.cpp
+++ b/tests/test_solver.cpp
@@ -165,7 +165,7 @@ TEST_CASE("solve-partial")
     std::array<uint8_t, 32> plot_id = Utils::hexToBytes(plot_id_hex);
 
     ProofParams params(
-        plot_id.data(), numeric_cast<uint8_t>(k), numeric_cast<uint8_t>(plot_strength));
+        plot_id.data(), numeric_cast<uint8_t>(k), numeric_cast<uint8_t>(plot_strength), 0);
     ProofCore proof_core(params);
     ProofFragmentCodec fragment_codec(params);
 


### PR DESCRIPTION
despite using the same k-value.
Also, extend the tests to cover testnet/mainnet and different plot index and meta groups