### PR TITLE
add benchmark

### DIFF
--- a/.github/workflows/bench-build.yaml
+++ b/.github/workflows/bench-build.yaml
@@ -1,0 +1,41 @@
+name: Benchmark build
+
+# Compile `chia-pos2` Criterion benchmarks only (`--no-run`). Does not execute them.
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  compile-benches:
+    name: Compile benches (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Build benchmark targets (no run)
+        run: cargo bench -p chia-pos2 --no-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +90,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -103,6 +121,7 @@ version = "0.4.2"
 dependencies = [
  "arbitrary",
  "cc",
+ "criterion",
  "rstest",
  "serde",
  "serde-big-array",
@@ -125,6 +144,33 @@ dependencies = [
  "clap",
  "hex",
  "sha2",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -183,6 +229,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +298,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -297,6 +389,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +410,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -325,10 +434,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -363,10 +498,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
@@ -487,6 +643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +697,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +747,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -626,6 +814,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +839,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -737,3 +944,29 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ clap = "4.5.38"
 sha2 = "0.10.9"
 hex = "0.4.3"
 arbitrary = "1.4.2"
+criterion = { version = "0.5.1", default-features = false }

--- a/crates/chia-pos2/Cargo.toml
+++ b/crates/chia-pos2/Cargo.toml
@@ -27,4 +27,9 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 cc = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 rstest = { workspace = true }
+
+[[bench]]
+name = "pos2_bench"
+harness = false

--- a/crates/chia-pos2/benches/pos2_bench.rs
+++ b/crates/chia-pos2/benches/pos2_bench.rs
@@ -1,0 +1,152 @@
+//! Throughput benchmarks for `chia_pos2` FFI-heavy APIs.
+//!
+//! **Plot file:** expects the same file the `test_plot_roundtrip` unit test creates for
+//! mainnet, `index == 0`, `meta_group == 0`:
+//! `{std::env::temp_dir()}/pos2_chia_test_k20_i0_g0.plot`
+//!
+//! If it is missing, the benchmark exits with a short message. Generate the plot first, e.g.:
+//! ```text
+//! cargo test -p chia-pos2 'test_plot_roundtrip::testnet_1_false::index_1_0u16::meta_group_1_0u8' -- --ignored
+//! ```
+
+use std::env;
+use std::hint::black_box;
+use std::path::Path;
+use std::process;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use chia_pos2::{
+    Bytes32, Prover, QualityChain, quality_string_from_proof, solve_proof, validate_proof_v2,
+};
+
+fn default_plot_path() -> std::path::PathBuf {
+    env::temp_dir().join("pos2_chia_test_k20_i0_g0.plot")
+}
+
+fn exit_missing_plot(path: &Path) -> ! {
+    eprintln!(
+        "Benchmark plot file not found.\n\
+         Expected path: {}\n\
+         This file is created by the `test_plot_roundtrip` test in `crates/chia-pos2/src/lib.rs` \
+         (mainnet, index=0, meta_group=0).\n\
+         Generate it with:\n\
+           cargo test -p chia-pos2 --release 'test_plot_roundtrip::testnet_1_false::index_1_0u16::meta_group_1_0u8' -- --ignored\n",
+        path.display()
+    );
+    process::exit(1);
+}
+
+struct Fixture {
+    prover: Prover,
+    plot_id: Bytes32,
+    k: u8,
+    strength: u8,
+    testnet: bool,
+    challenge: Bytes32,
+    quality: QualityChain,
+    proof: Vec<u8>,
+}
+
+fn load_fixture() -> Fixture {
+    let path = default_plot_path();
+    if !path.exists() {
+        exit_missing_plot(&path);
+    }
+    let prover = Prover::new(&path).unwrap_or_else(|e| {
+        eprintln!("Failed to open plot {}: {e}", path.display());
+        process::exit(1);
+    });
+    let plot_id = *prover.plot_id();
+    let k = prover.size();
+    let strength = prover.get_strength();
+    let testnet = false;
+
+    let mut challenge = [0u8; 32];
+    let mut found: Option<(Bytes32, QualityChain)> = None;
+    for challenge_idx in 0u32..4096 {
+        challenge[0..4].copy_from_slice(&challenge_idx.to_le_bytes());
+        let qualities = prover
+            .get_qualities_for_challenge(&challenge)
+            .expect("get_qualities_for_challenge");
+        if let Some(q) = qualities.into_iter().next() {
+            found = Some((challenge, q));
+            break;
+        }
+    }
+    let (challenge, quality) = found.expect(
+        "Fixture plot produced no qualities for challenges 0..4096; delete the plot and regenerate \
+         with test_plot_roundtrip.",
+    );
+
+    let proof = solve_proof(&quality, &plot_id, k, strength, testnet);
+    assert!(
+        !proof.is_empty(),
+        "solve_proof returned an empty proof for the fixture challenge — plot may be corrupt"
+    );
+
+    Fixture {
+        prover,
+        plot_id,
+        k,
+        strength,
+        testnet,
+        challenge,
+        quality,
+        proof,
+    }
+}
+
+fn pos2_benchmarks(c: &mut Criterion) {
+    let f = load_fixture();
+
+    c.bench_function("get_qualities_for_challenge", |b| {
+        b.iter(|| {
+            black_box(
+                f.prover
+                    .get_qualities_for_challenge(black_box(&f.challenge))
+                    .unwrap(),
+            )
+        })
+    });
+
+    c.bench_function("solve_proof", |b| {
+        b.iter(|| {
+            black_box(solve_proof(
+                black_box(&f.quality),
+                black_box(&f.plot_id),
+                f.k,
+                f.strength,
+                f.testnet,
+            ))
+        })
+    });
+
+    c.bench_function("validate_proof_v2", |b| {
+        b.iter(|| {
+            black_box(validate_proof_v2(
+                black_box(&f.plot_id),
+                f.k,
+                black_box(&f.challenge),
+                f.strength,
+                black_box(f.proof.as_slice()),
+                f.testnet,
+            ))
+        })
+    });
+
+    c.bench_function("quality_string_from_proof", |b| {
+        b.iter(|| {
+            black_box(quality_string_from_proof(
+                black_box(&f.plot_id),
+                f.k,
+                f.strength,
+                black_box(f.proof.as_slice()),
+                f.testnet,
+            ))
+        })
+    });
+}
+
+criterion_group!(benches, pos2_benchmarks);
+criterion_main!(benches);


### PR DESCRIPTION
This adds a benchmark for some of the key functions in PoS2. One quirk is that the benchmark won't create the test plot itself, it depends on running the regular unit tests  first to do that.

```
get_qualities_for_challenge
                        time:   [4.8223 ms 4.8294 ms 4.8376 ms]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

solve_proof             time:   [15.855 ms 16.350 ms 16.897 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

validate_proof_v2       time:   [7.4221 µs 7.5475 µs 7.7457 µs]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

quality_string_from_proof
                        time:   [1.2221 µs 1.2284 µs 1.2354 µs]
Found 18 outliers among 100 measurements (18.00%)
  13 (13.00%) high mild
  5 (5.00%) high severe
```