### PR TITLE
Add postune analytics tool

### DIFF
--- a/src/tools/postune/index.html
+++ b/src/tools/postune/index.html
@@ -1,0 +1,707 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Attack Effectiveness Comparison</title>
+
+    <style>
+        body {
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #0f172a;
+            color: #e5e7eb;
+            margin: 0;
+            padding: 2rem;
+            display: flex;
+            justify-content: center;
+        }
+
+        .card {
+            background: #020617;
+            border-radius: 12px;
+            padding: 1.5rem 2rem;
+            max-width: 100%;
+            width: 100%;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+            border: 1px solid #1f2937;
+            overflow-x: auto;
+        }
+
+        .card h1 {
+            font-size: 1.3rem;
+            margin: 0 0 1.25rem;
+            color: #f9fafb;
+        }
+
+        table.results-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+            min-width: 800px;
+            /* ensures header stays readable */
+        }
+
+        .results-table thead {
+            background: #111827;
+            position: sticky;
+            top: 0;
+            z-index: 1;
+        }
+
+        .results-table th,
+        .results-table td {
+            padding: 0.5rem 0.75rem;
+            text-align: right;
+            border-bottom: 1px solid #1f2937;
+            vertical-align: middle;
+        }
+
+        .results-table th:first-child,
+        .results-table td:first-child {
+            text-align: left;
+            position: sticky;
+            left: 0;
+            background: #020617;
+            z-index: 2;
+        }
+
+        .results-table th {
+            font-weight: 600;
+            color: #d1d5db;
+            white-space: nowrap;
+        }
+
+        .results-table tbody tr:nth-child(even) {
+            background: #020617;
+        }
+
+        .results-table tbody tr:nth-child(odd) {
+            background: #030712;
+        }
+
+        .results-table tbody tr:hover {
+            background: #111827;
+        }
+
+        .run-label {
+            font-weight: 600;
+            color: #e5e7eb;
+            white-space: nowrap;
+        }
+
+        .metric-value {
+            font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            color: #a5b4fc;
+            white-space: nowrap;
+        }
+
+        .unit-note {
+            font-size: 0.8rem;
+            color: #9ca3af;
+            margin-top: 0.75rem;
+            opacity: 0.9;
+        }
+
+        .no-results {
+            padding: 0.75rem;
+            text-align: center;
+            color: #9ca3af;
+            font-style: italic;
+        }
+
+        /* New controls header styling */
+        .controls {
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+            margin-bottom: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .controls label {
+            font-size: 0.95rem;
+            color: #cbd5e1;
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+        }
+
+        .controls input[type="range"] {
+            width: 160px;
+        }
+
+        .controls input[type="number"] {
+            width: 5rem;
+            padding: 0.15rem 0.35rem;
+            border-radius: 6px;
+            border: 1px solid #2b3440;
+            background: #071026;
+            color: #e5e7eb;
+        }
+
+        /* Summary styles */
+        .summary {
+            margin: 0.5rem 0 1rem 0;
+            padding: 0.75rem 0.75rem;
+            background: #0b1229;
+            border: 1px solid #1f2937;
+            border-radius: 8px;
+        }
+
+        .summary-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+
+        .summary-item {
+            flex: 1 1 280px;
+            min-width: 260px;
+            background: #0a0f24;
+            border: 1px solid #1e293b;
+            border-radius: 8px;
+            padding: 0.5rem 0.75rem;
+        }
+
+        .summary-label {
+            font-size: 0.85rem;
+            color: #9ca3af;
+            margin-bottom: 0.25rem;
+        }
+
+        .summary-value {
+            font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            color: #a5b4fc;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .summary-value pre {
+            margin: 0;
+            white-space: pre-wrap;
+        }
+
+        .summary-value ul {
+            margin: 0;
+            padding-left: 1.1rem;
+        }
+
+        .summary-value li {
+            line-height: 1.3;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="card">
+        <h1>Attack Effectiveness Comparison</h1>
+
+        <!-- New header controls: plot id filter bits and netspace EiB input -->
+        <div class="controls">
+            <label>
+                Plot ID filter bits:
+                <input id="plot-bits" type="range" min="6" max="18" value="10" step="1" />
+                <span id="plot-bits-value">10</span>
+                <span id="plot-base-value" style="margin-left:0.5rem">Base: 1024</span>
+            </label>
+
+            <label>
+                Netspace Attack (EiB):
+                <input id="netspace-eib" type="number" min="1" value="10" />
+            </label>
+
+            <!-- Added: proof fragment scan filter range bits -->
+            <label>
+                Proof fragment scan filter range bits:
+                <input id="scan-range-bits" type="range" min="5" max="13" value="10" step="1" />
+                <span id="scan-range-bits-value">10</span>
+                <span id="scan-range-base-value" style="margin-left:0.5rem">Range: 1024</span>
+            </label>
+        </div>
+
+        <!-- New: summary output shown under header and above the results table -->
+        <div id="summary" class="summary">
+            <div class="summary-row">
+                <div class="summary-item">
+                    <div class="summary-label">Plot/Validation time by strength</div>
+                    <div class="summary-value" id="summary-plotting-time">—</div>
+                </div>
+                <div class="summary-item">
+                    <div class="summary-label">Devices needed (rental attack)</div>
+                    <div class="summary-value" id="summary-rental-devices">—</div>
+                </div>
+            </div>
+        </div>
+
+        <table class="results-table">
+            <thead>
+                <tr id="header-row">
+                    <!-- Filled by JavaScript -->
+                </tr>
+            </thead>
+            <tbody id="results-body">
+                <!-- Filled by JavaScript -->
+            </tbody>
+        </table>
+
+        <div class="unit-note">
+            * Sizes are in TB (decimal, 1 TB = 10<sup>12</sup> bytes).<br />
+            * Costs and power are reported per TB of saved bytes.
+        </div>
+    </div>
+
+    <!-- 1. Load postune.js first so its globals are available -->
+    <script src="./postune.js"></script>
+
+    <!-- 2. Then run our logic (updated to use the controls and rebuild on change) -->
+    <script>
+        'use strict';
+
+        function formatValue(key, value) {
+            if (value === null || value === undefined) return '';
+
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                return String(value);
+            }
+
+            // TB values
+            if (key.includes('size (TB)')) {
+                return value.toFixed(3) + ' TB';
+            }
+
+            // Byte counts
+            if (key.includes('(bytes)')) {
+                return value.toLocaleString('en-US') + ' bytes';
+            }
+
+            // Compression
+            if (key.toLowerCase().includes('compression')) {
+                return value.toFixed(3);
+            }
+
+            // Per TB metrics
+            if (key.includes('per TB')) {
+                return value.toFixed(3);
+            }
+
+            // Default: up to 3 decimal places
+            const rounded = Math.round(value * 1000) / 1000;
+            return String(rounded);
+        }
+
+        function buildTable(resultsArray) {
+            const headerRow = document.getElementById('header-row');
+            const tbody = document.getElementById('results-body');
+
+            headerRow.innerHTML = '';
+            tbody.innerHTML = '';
+
+            if (!Array.isArray(resultsArray) || resultsArray.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 99;
+                td.className = 'no-results';
+                td.textContent = 'No results to display.';
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+                return;
+            }
+
+            // Collect union of all metric keys (columns)
+            const metricSet = new Set();
+            for (const result of resultsArray) {
+                if (!result || !result.data) continue;
+                for (const key of Object.keys(result.data)) {
+                    metricSet.add(key);
+                }
+            }
+            const metrics = Array.from(metricSet);
+
+            if (metrics.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 99;
+                td.className = 'no-results';
+                td.textContent = 'Results found, but no metrics to display.';
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+                return;
+            }
+
+            // Build header: first column is the run label, rest are metrics
+            const thRun = document.createElement('th');
+            thRun.textContent = 'Run';
+            headerRow.appendChild(thRun);
+
+            for (const metric of metrics) {
+                const th = document.createElement('th');
+                th.textContent = metric;
+                headerRow.appendChild(th);
+            }
+
+            // Build rows
+            resultsArray.forEach((entry, index) => {
+                const tr = document.createElement('tr');
+
+                // Run label cell
+                const tdLabel = document.createElement('td');
+                tdLabel.className = 'run-label';
+                tdLabel.textContent = entry.label || `Run ${index + 1}`;
+                tr.appendChild(tdLabel);
+
+                // Metric cells
+                for (const metric of metrics) {
+                    const td = document.createElement('td');
+                    td.className = 'metric-value';
+                    const rawValue = entry.data ? entry.data[metric] : undefined;
+                    td.textContent = formatValue(metric, rawValue);
+                    tr.appendChild(td);
+                }
+
+                tbody.appendChild(tr);
+            });
+        }
+
+        // Hook up controls and dynamic behavior
+        (function () {
+            try {
+                // Elements
+                const bitsInput = document.getElementById('plot-bits');
+                const bitsValue = document.getElementById('plot-bits-value');
+                const baseValue = document.getElementById('plot-base-value');
+                const netspaceInput = document.getElementById('netspace-eib');
+
+                // New scan-range elements
+                const scanInput = document.getElementById('scan-range-bits');
+                const scanValue = document.getElementById('scan-range-bits-value');
+                const scanBase = document.getElementById('scan-range-base-value');
+
+                function updateBaseDisplay() {
+                    const bits = Number(bitsInput.value);
+                    bitsValue.textContent = bits;
+                    baseValue.textContent = 'Base: ' + (1 << bits);
+                }
+
+                function updateScanDisplay() {
+                    const bits = Number(scanInput.value);
+                    scanValue.textContent = bits;
+                    scanBase.textContent = 'Range: ' + (1 << bits);
+                }
+
+                function getSettings() {
+                    const bits = Number(bitsInput.value);
+                    return {
+                        bits,
+                        baseFilter: 1 << bits,
+                        netspaceEiB: Math.max(1, Number(netspaceInput.value) || 10),
+                        scanRangeBits: Number(scanInput.value),
+                        scanRangeBase: 1 << Number(scanInput.value)
+                    };
+                }
+
+                // Helper: format arbitrary values robustly for the summary
+                function summarizeValue(val) {
+                    if (val === null || val === undefined) return '—';
+                    if (typeof val === 'number') {
+                        const abs = Math.abs(val);
+                        if (abs >= 1000) return val.toLocaleString('en-US');
+                        return (Math.round(val * 1000) / 1000).toString();
+                    }
+                    if (typeof val === 'string') return val;
+                    // objects/arrays: pretty print but compact
+                    try {
+                        return JSON.stringify(val, null, 2);
+                    } catch {
+                        return String(val);
+                    }
+                }
+
+                // New helper: 3 significant digits formatter (avoids scientific when possible)
+                function formatSig3(v) {
+                    if (typeof v !== 'number' || !Number.isFinite(v)) return String(v);
+                    const av = Math.abs(v);
+                    // Avoid scientific notation around ~1e3 by manual rounding
+                    if (av >= 100) return Math.round(v).toString();           // 3 sig figs for 100..999
+                    if (av >= 10)  return (Math.round(v * 10) / 10).toString(); // 2 decimals -> 3 sig figs
+                    if (av >= 1)   return (Math.round(v * 100) / 100).toString(); // 2 decimals
+                    // Fallback for very small values
+                    let s = Number(v).toPrecision(3);
+                    if (s.includes('e')) {
+                        // try plain with up to 6 decimals to avoid sci notation
+                        s = (Math.round(v * 1e6) / 1e6).toString();
+                    }
+                    return s;
+                }
+
+                // New helper: format ms into a human-friendly duration
+                function formatDurationMs(ms) {
+                    if (typeof ms !== 'number' || !Number.isFinite(ms)) return String(ms);
+                    const abs = Math.abs(ms);
+                    const sec = 1000;
+                    const min = 60 * sec;
+                    const hour = 60 * min;
+                    const day = 24 * hour;
+
+                    function fmt(v) {
+                        const av = Math.abs(v);
+                        if (av >= 100) return Math.round(v).toString();
+                        if (av >= 10) return (Math.round(v * 10) / 10).toString();
+                        return (Math.round(v * 100) / 100).toString();
+                    }
+
+                    // Use 3 significant digits when showing milliseconds
+                    if (abs < sec) return formatSig3(ms) + ' ms';
+                    if (abs < min) return fmt(ms / sec) + ' s';
+                    if (abs < hour) return fmt(ms / min) + ' min';
+                    if (abs < day) return fmt(ms / hour) + ' h';
+                    return fmt(ms / day) + ' d';
+                }
+
+                // New helper: TB/day from plotting time (ms) and honest_plot_size_bytes
+                function computeTBPerDay(ms) {
+                    const MS_PER_DAY = 86_400_000;
+                    const bytes = (typeof honest_plot_size_bytes === 'number') ? honest_plot_size_bytes : 0;
+                    if (!Number.isFinite(ms) || ms <= 0 || !Number.isFinite(bytes) || bytes <= 0) return 0;
+                    return (bytes / 1e12) * (MS_PER_DAY / ms);
+                }
+
+                // Render summary values under the header
+                function renderSummary(timesByStrength, devices_needed_for_rental_attack) {
+                    const ptEl = document.getElementById('summary-plotting-time');
+                    const devEl = document.getElementById('summary-rental-devices');
+                    if (!ptEl || !devEl) return;
+
+                    // List items: s N: plot=<val>, validate=<val>, tb/day=<val>
+                    if (Array.isArray(timesByStrength) && timesByStrength.length) {
+                        let html = '<ul>';
+                        for (const item of timesByStrength) {
+                            const s = (item && typeof item.strength === 'number') ? item.strength : '?';
+                            const plotStr = (item && typeof item.plot === 'number')
+                                ? formatDurationMs(item.plot)
+                                : summarizeValue(item?.plot);
+                            const validateStr = (item && typeof item.validate === 'number')
+                                ? formatDurationMs(item.validate)
+                                : summarizeValue(item?.validate);
+                            const tbpdStr = summarizeValue(item.tbpd);
+                            html += '<li>s ' + s + ': plot=' + plotStr + ', validate=' + validateStr + ', tb/day=' + tbpdStr + '</li>';
+                        }
+                        html += '</ul>';
+                        ptEl.innerHTML = html;
+                    } else {
+                        ptEl.textContent = '—';
+                    }
+
+                    const devStr = summarizeValue(devices_needed_for_rental_attack);
+                    devEl.innerHTML = devStr.startsWith && (devStr.startsWith('{') || devStr.startsWith('['))
+                        ? '<pre>' + devStr + '</pre>'
+                        : devStr;
+                }
+
+                function buildResultsAndTable() {
+                    try {
+                        // Use postune.js globals
+                        const deviceParams = device_params_5090;
+                        const s = getSettings();
+                        var plotParams = get_plot_params(s.baseFilter, 2);
+                        plotParams.scan_filter_bits = s.scanRangeBits;
+
+                        const attackResults = [];
+
+                        //attackResults.push({
+                        //    label: 'Challenge Components Bit Dropping Attack (strength: ' + plotParams.strength_bits + ' ' + (1 << plotParams.scan_filter_bits) + ' - bitdrop -2)',
+                        //    data: calc_attack_challenge_components_bit_dropping(plotParams, deviceParams, -2)
+                        //});
+
+                        var pfParams = get_plot_params(s.baseFilter, strength_cap);
+                        pfParams.scan_filter_bits = s.scanRangeBits;
+                        attackResults.push({
+                            label: 'Proof Fragments Attack ('+ pfParams.strength_bits + ' strength, 1 bits dropped)',
+                            data: calc_attack_proof_fragments_drop_bits(pfParams, deviceParams, 1)
+                        });
+
+                        //pfParams = get_plot_params(s.baseFilter, 2);
+                        //pfParams.scan_filter_bits = s.scanRangeBits;
+                        //attackResults.push({
+                        //    label: 'Proof Fragments Attack ('+ pfParams.strength_bits + ' strength, 1 bits dropped)',
+                        //    data: calc_attack_proof_fragments_drop_bits(pfParams, deviceParams, 1)
+                        //});
+
+                        /*
+                        // technically this is our solver time:
+                        plotParams.scan_filter_bits = 4;
+                        attackResults.push({
+                            label: 'Proof Fragments Attack (' + (1 << plotParams.scan_filter_bits) + ' - bitdrop 0)',
+                            data: calc_attack_proof_fragments_drop_bits(plotParams, deviceParams, 0)
+                        });
+                        */
+                        /*
+                        attackResults.push({
+                            label: 'Collected XS Attack (2048)',
+                            data: calc_attack_collected_xs(2048, plotParams, deviceParams)
+                        });
+
+                        attackResults.push({
+                            label: 'Collected LXS Attack (512)',
+                            data: calc_attack_collected_lxs(512, plotParams, deviceParams)
+                        });
+                        attackResults.push({
+                            label: 'Collected LXS Attack (1024)',
+                            data: calc_attack_collected_lxs(1024, plotParams, deviceParams)
+                        });
+
+                        attackResults.push({
+                            label: 'Challenge Components Bit Dropping Attack (' + (1 << plotParams.scan_filter_bits) + ' - bitdrop 1)',
+                            data: calc_attack_challenge_components_bit_dropping(plotParams, deviceParams, 1)
+                        });
+                        attackResults.push({
+                            label: 'Challenge Components Bit Dropping Attack (' + (1 << plotParams.scan_filter_bits) + ' - bitdrop 0)',
+                            data: calc_attack_challenge_components_bit_dropping(plotParams, deviceParams, 0)
+                        });
+                        attackResults.push({
+                            label: 'Challenge Components Bit Dropping Attack (' + (1 << plotParams.scan_filter_bits) + ' - bitadd 1)',
+                            data: calc_attack_challenge_components_bit_dropping(plotParams, deviceParams, -1)
+                        });
+                        attackResults.push({
+                            label: 'Challenge Components Bit Dropping Attack (' + (1 << plotParams.scan_filter_bits) + ' - bitadd 2)',
+                            data: calc_attack_challenge_components_bit_dropping(plotParams, deviceParams, -2)
+                        });
+
+                        attackResults.push({
+                            label: 'Proof Fragments Attack (16 fragments, 0 bits dropped)',
+                            data: calc_attack_proof_fragments_drop_bits(plotParams, deviceParams, 16, 0)
+                        });
+                        attackResults.push({
+                            label: 'Proof Fragments Attack (1024 fragments, 1 bits dropped)',
+                            data: calc_attack_proof_fragments_drop_bits(plotParams, deviceParams, 1024, 1)
+                        });
+                        attackResults.push({
+                            label: 'Proof Fragments Attack (1024 fragments, 8 bits dropped)',
+                            data: calc_attack_proof_fragments_drop_bits(plotParams, deviceParams, 1024, 8)
+                        });
+                        attackResults.push({
+                            label: 'Proof Fragments Attack (1024 fragments, 16 bits dropped)',
+                            data: calc_attack_proof_fragments_drop_bits(plotParams, deviceParams, 1024, 16)
+                        });
+                        attackResults.push({
+                            label: 'Attack Strength Match Bits (strength: ' + plotParams.strength_bits + ')',
+                            data: calc_attack_strength_match_bits(plotParams, deviceParams)
+                        });
+                        attackResults.push({
+                            label: 'Attack Strength Match Bits (strength: ' + 10 + ')',
+                            data: calc_attack_strength_match_bits(get_plot_params(s.baseFilter, 10), deviceParams)
+                        });*/
+
+
+                        // side-effect calculations; pass netspace EiB into the pure rental attack
+
+                        var result = get_highest_effectiveness_challenge_components_attack(plotParams, deviceParams);
+                        var bestPlotParams = get_plot_params(s.baseFilter, result.best_strength_bits);
+                        bestPlotParams.scan_filter_bits = plotParams.scan_filter_bits;
+                        attackResults.push({
+                            label: 'Challenge Components Bit Dropping Attack (' + (1 << plotParams.scan_filter_bits) + ' - strength: ' + bestPlotParams.strength_bits + ' - bitdrop ' + result.best_drop_bits + ')',
+                            data: calc_attack_challenge_components_bit_dropping(bestPlotParams, deviceParams, result.best_drop_bits)
+                        });
+
+                        result = get_highest_effective_collected_xs_attack(plotParams, deviceParams);
+                        bestPlotParams = get_plot_params(s.baseFilter, result.best_strength);
+                        bestPlotParams.scan_filter_bits = plotParams.scan_filter_bits;
+                        attackResults.push({
+                            label: 'Collected XS Attack (sets:' + result.best_challenge_sets_covered + ' - strength: ' + bestPlotParams.strength_bits + ')',
+                            data: calc_attack_collected_xs(result.best_challenge_sets_covered, bestPlotParams, deviceParams)
+                        });
+
+                        result = get_highest_effective_collected_lxs_attack(plotParams, deviceParams);
+                        bestPlotParams = get_plot_params(s.baseFilter, result.best_strength);
+                        bestPlotParams.scan_filter_bits = plotParams.scan_filter_bits;
+                        attackResults.push({
+                            label: 'Collected LXS Attack (sets:' + result.best_challenge_sets_covered + ' - strength: ' + bestPlotParams.strength_bits + ')',
+                            data: calc_attack_collected_lxs(result.best_challenge_sets_covered, bestPlotParams, deviceParams)
+                        });
+
+                        //result = get_highest_effective_proof_fragments_drop_bits_attack(plotParams, deviceParams);
+                        //bestPlotParams = get_plot_params(s.baseFilter, result.best_strength);
+                        //bestPlotParams.scan_filter_bits = plotParams.scan_filter_bits;
+                        //attackResults.push({
+                        //    label: 'Proof Fragments Attack (fragments:' + (1 << bestPlotParams.scan_filter_bits) + ' - strength: ' + bestPlotParams.strength_bits + ' - bits dropped: ' + result.best_bits_dropped + ')',
+                        //    data: calc_attack_proof_fragments_drop_bits(bestPlotParams, deviceParams, result.best_bits_dropped)
+                        //});
+
+                        result = get_highest_effective_strength_match_bits_attack(plotParams, deviceParams);
+                        bestPlotParams = get_plot_params(s.baseFilter, result.best_strength);
+                        bestPlotParams.scan_filter_bits = plotParams.scan_filter_bits;
+                        attackResults.push({
+                            label: 'Attack Strength Match Bits (strength: ' + bestPlotParams.strength_bits + ')',
+                            data: calc_attack_strength_match_bits(bestPlotParams, deviceParams)
+                        });
+
+                        // Compute devices needed first
+                        var rentalAttackPlotParams = get_plot_params(s.baseFilter, 10);
+                        var devices_needed_for_rental_attack =
+                            calc_pure_rental_attack(rentalAttackPlotParams, device_params_5090, getSettings().netspaceEiB);
+
+                        // Compute plotting and validation time for each strength (2..13)
+                        const timesByStrength = [];
+                        for (var strength = 2; strength <= 10; strength++) {
+                            var sp = get_plot_params(plotParams.plot_id_base_filter, strength);
+                            sp.scan_filter_bits = plotParams.scan_filter_bits;
+                            var pt = calc_plotting_time(sp, device_params_5090);
+                            var vt = calc_validation_time(sp, device_params_pi5);
+                            var tbpd = computeTBPerDay(pt);
+                            timesByStrength.push({ strength, plot: pt, validate: vt, tbpd });
+                        }
+
+                        // Add a synthetic row to the results table to display these times
+                        const timeMetrics = {};
+                        for (const t of timesByStrength) {
+                            timeMetrics['plot s' + t.strength] = t.plot;
+                            timeMetrics['validate s' + t.strength] = t.validate;
+                            timeMetrics['TB/day s' + t.strength] = t.tbpd;
+                        }
+
+                        // Update summary UI
+                        renderSummary(timesByStrength, devices_needed_for_rental_attack);
+
+                        // Render table
+                        buildTable(attackResults);
+                    } catch (err) {
+                        console.error('Error building attack results table:', err);
+                        const tbody = document.getElementById('results-body');
+                        if (tbody) {
+                            const tr = document.createElement('tr');
+                            const td = document.createElement('td');
+                            td.colSpan = 99;
+                            td.className = 'no-results';
+                            td.textContent = 'Error while generating results. Check console for details.';
+                            tr.appendChild(td);
+                            tbody.appendChild(tr);
+                        }
+                    }
+                }
+
+                // Initialize display and attach handlers
+                updateBaseDisplay();
+                updateScanDisplay();
+                bitsInput.addEventListener('input', () => {
+                    updateBaseDisplay();
+                    buildResultsAndTable();
+                });
+                // rebuild when scan-range changes
+                scanInput.addEventListener('input', () => {
+                    updateScanDisplay();
+                    buildResultsAndTable();
+                });
+                netspaceInput.addEventListener('change', () => {
+                    buildResultsAndTable();
+                });
+
+                // initial build
+                buildResultsAndTable();
+
+            } catch (err) {
+                console.error('Initialization error:', err);
+            }
+        })();
+    </script>
+</body>
+
+</html>

--- a/src/tools/postune/postune.js
+++ b/src/tools/postune/postune.js
@@ -1,0 +1,940 @@
+var k = 28;
+var num_entries_per_table = 1 << k;
+var honest_bits_per_entry = 29.45;
+var honest_plot_size_bytes = num_entries_per_table * honest_bits_per_entry / 8;
+var strength_cap = 2+4;
+
+// Number of distinct challenge fragment sets selected per challenge. Must mirror
+// NUM_CHALLENGE_SETS in src/pos/ProofConstants.hpp. The attacker must scan
+// proof fragments from each of these sets per challenge, so per-challenge work
+// scales linearly with this value.
+var NUM_CHALLENGE_SETS = 4;
+
+var benchmarks = {
+    "nvidia_rtx_5090": {
+        rounds32: {
+            g_x: 4303851,
+            matching_target: 4289555,
+            pairing: 4243035
+        },
+        sortXs: 18057265,
+        sortT1: 12619378,
+        sortT2: 8045923,
+        sortT3: 10178859
+    }
+}
+
+//var base_plot_id_filter = 4096;
+var default_scan_filter_bits = 11;
+
+// 2 sets strength to strength bits, 0 sets strength starting at 0.
+var pairing_strength_start = 2;
+var t1_match_bits_base = 2;
+var hash_speedup = 1;
+
+
+var device_params_5090 = {
+    g_hashes_per_ms: 9925926*hash_speedup,       // the g(x) function
+    pair_hashes_per_ms: 9925926*hash_speedup,     // once we have a match, the hash to pair them to get next meta
+    target_hashes_per_ms: 9925926*hash_speedup,      // given a left side pairing, time to hash (meta + mi) target bits
+    sortXs: 18057265,
+    sortT1: 12619378,
+    sortT2: 8045923,
+    sortT3: 10178859,
+    sloths_per_ms: 0 // 9925926         // time to do sloth encoding
+};
+
+var device_params_pi5 = {
+    g_hashes_per_ms: 74362*hash_speedup,       // the g(x) function
+    pair_hashes_per_ms: 74362*hash_speedup,     // once we have a match, the hash to pair them to get next meta
+    target_hashes_per_ms: 74362*hash_speedup,      // given a left side pairing, time to hash (meta + mi) target bits
+    sortXs: 0,
+    sortT1: 0,
+    sortT2: 0,
+    sortT3: 0,
+    sloths_per_ms: 0 // 9925926         // time to do sloth encoding
+}
+var default_plot_params = {
+    scan_filter_bits: default_scan_filter_bits,
+    strength_bits: 2,
+    t1_match_bits: 2,
+    t2_match_bits: 2,
+    t3_match_bits: 4
+};
+var default_equipment_params = {
+    gpu_w: 400,
+    gpu_cost: 2000,
+    gpu_name: "NVIDIA RTX 5090",
+    storage_w_per_tb: 0.55,
+    storage_cost_per_tb: 10
+}
+function get_plot_params(base_plot_id_filter, plot_strength_bits) {
+    // strength 2 t1/2/3 match bits = 2,2,2
+    // strength 3 t1/2/3 match bits = 3,2,2
+    // strength 4 t1/2/3 match bits = 4,2,2
+    // strength 5 t1/2/3 match bits = 5,2,2
+    // strength 6 t1/2/3 match bits = 5,3,3
+    // strength 7 t1/2/3 match bits = 5,4,4
+    var t1_match_bits = t1_match_bits_base;
+    var t2_match_bits = 2 + plot_strength_bits - 2;
+    var t3_match_bits = 2 + plot_strength_bits - 2;
+    return {
+        base_plot_id_filter: base_plot_id_filter,
+        scan_filter_bits: default_scan_filter_bits,
+        strength_bits: plot_strength_bits,
+        t1_match_bits: t1_match_bits,
+        t2_match_bits: t2_match_bits,
+        t3_match_bits: t3_match_bits,
+        effective_plot_id_filter: base_plot_id_filter * (1 << (plot_strength_bits - 2))
+    }
+}
+function get_num_supported_plots_per_challenge(plot_params, challenge_time_ms) {
+    return plot_params.effective_plot_id_filter * 9375 / challenge_time_ms;
+}
+function calc_attack_effectiveness(plot_params, equipment_params, challenge_time_ms, attacker_bits_per_entry) {
+    console.log(`Calculating attack effectiveness with attacker bits per entry: ${attacker_bits_per_entry.toFixed(4)}`);
+    console.table(plot_params);
+    var num_supported_plots = get_num_supported_plots_per_challenge(plot_params, challenge_time_ms);
+    var honest_farm_bytes = num_supported_plots * honest_plot_size_bytes;
+    var attacker_compression = attacker_bits_per_entry / honest_bits_per_entry;
+    var attacker_plot_bytes = attacker_compression * honest_plot_size_bytes;
+    var attacker_farm_bytes = num_supported_plots * attacker_plot_bytes;
+
+    // calculate saved bytes and gpu w per tb on those saved bytes. This will show if more effective
+    // than honest farming.
+    var attacker_saved_bytes = honest_farm_bytes - attacker_farm_bytes;
+    var attacker_saved_TB = attacker_saved_bytes / (1000 * 1000 * 1000 * 1000);
+    var attacker_gpu_w_per_tb_on_saved_bytes = equipment_params.gpu_w / (attacker_saved_TB);
+    var attacker_gpu_cost_per_tb_on_saved_bytes = equipment_params.gpu_cost / (attacker_saved_TB);
+    var attacker_w_per_tb_ratio_to_honest_w_per_tb = attacker_gpu_w_per_tb_on_saved_bytes / equipment_params.storage_w_per_tb;
+    var attacker_cost_per_tb_relative_to_honest_cost_per_tb = attacker_gpu_cost_per_tb_on_saved_bytes / equipment_params.storage_cost_per_tb;
+    var attacker_effectiveness = 1 / (attacker_w_per_tb_ratio_to_honest_w_per_tb * attacker_cost_per_tb_relative_to_honest_cost_per_tb);
+    if (attacker_bits_per_entry >= honest_bits_per_entry) {
+        attacker_effectiveness = 0;
+    }
+    if (challenge_time_ms > 9375) {
+        attacker_effectiveness = 0;
+    }
+
+    var results = {
+        attacker_effectiveness: attacker_effectiveness,
+        "Attacker compression": attacker_compression,
+        attacker_w_per_tb_ratio_to_honest_w_per_tb: attacker_w_per_tb_ratio_to_honest_w_per_tb,
+        attacker_cost_per_tb_relative_to_honest_cost_per_tb: attacker_cost_per_tb_relative_to_honest_cost_per_tb,
+        challenge_time_ms: challenge_time_ms,
+        attacker_bits_per_entry: attacker_bits_per_entry,
+        "Num supported plots per GPU": num_supported_plots,
+        "Honest farm size (TB)": honest_farm_bytes / (1000 * 1000 * 1000 * 1000),
+        "Attacker plot size (bytes)": attacker_plot_bytes,
+        "Attacker farm size (TB)": attacker_farm_bytes / (1000 * 1000 * 1000 * 1000),
+        "Attacker saved size (TB)": attacker_saved_TB,
+        "Attacker GPU W per TB on saved bytes": attacker_gpu_w_per_tb_on_saved_bytes,
+        "Attacker GPU cost per TB on saved bytes": attacker_gpu_cost_per_tb_on_saved_bytes,
+
+    };
+    console.table(results);
+    return results;
+
+}
+
+const xsSetSizeData = {
+    // set size: { t3 num entries for challenge scanned, unique Xs, unique Lxs }
+    1: { numEntries: 4075, uniqueXs: 32595, uniqueLxs: 16299 },
+    2: { numEntries: 8119, uniqueXs: 64941, uniqueLxs: 32472 },
+    4: { numEntries: 16197, uniqueXs: 129503, uniqueLxs: 64762 },
+    8: { numEntries: 32735, uniqueXs: 261619, uniqueLxs: 130850 },
+    16: { numEntries: 65278, uniqueXs: 521316, uniqueLxs: 260778 },
+    32: { numEntries: 131140, uniqueXs: 1045410, uniqueLxs: 523183 },
+    64: { numEntries: 262153, uniqueXs: 2082761, uniqueLxs: 1043362 },
+    128: { numEntries: 523812, uniqueXs: 4134025, uniqueLxs: 2074963 },
+    256: { numEntries: 1047648, uniqueXs: 8158293, uniqueLxs: 4110615 },
+    512: { numEntries: 2096448, uniqueXs: 15897282, uniqueLxs: 8069569 },
+    1024: { numEntries: 4193845, uniqueXs: 30201842, uniqueLxs: 15550490 },
+    2048: { numEntries: 8390753, uniqueXs: 54777027, uniqueLxs: 28947232 },
+    4096: { numEntries: 16775355, uniqueXs: 91861059, uniqueLxs: 50722920 },
+    8192: { numEntries: 33541075, uniqueXs: 137090460, uniqueLxs: 80664455 }
+};
+function getXsSetSizeData(setsCovered) {
+    const keys = Object.keys(xsSetSizeData).map(Number).sort((a, b) => a - b);
+
+    // Exact match
+    if (xsSetSizeData[setsCovered]) {
+        return xsSetSizeData[setsCovered];
+    }
+
+    // Below minimum → clamp
+    if (setsCovered < keys[0]) {
+        return xsSetSizeData[keys[0]];
+    }
+
+    // Above maximum → clamp
+    if (setsCovered > keys[keys.length - 1]) {
+        return xsSetSizeData[keys[keys.length - 1]];
+    }
+
+    // Find bounding keys for interpolation
+    let lower = keys[0];
+    let upper = keys[keys.length - 1];
+
+    for (let i = 0; i < keys.length - 1; i++) {
+        if (setsCovered > keys[i] && setsCovered < keys[i + 1]) {
+            lower = keys[i];
+            upper = keys[i + 1];
+            break;
+        }
+    }
+
+    const t = (setsCovered - lower) / (upper - lower);
+
+    const lowData = xsSetSizeData[lower];
+    const upData = xsSetSizeData[upper];
+
+    function lerp(a, b, t) {
+        return a + (b - a) * t;
+    }
+
+    return {
+        numEntries: Math.round(lerp(lowData.numEntries, upData.numEntries, t)),
+        uniqueXs: Math.round(lerp(lowData.uniqueXs, upData.uniqueXs, t)),
+        uniqueLxs: Math.round(lerp(lowData.uniqueLxs, upData.uniqueLxs, t)),
+        interpolated: true,
+        from: [lower, upper]
+    };
+}
+
+function get_g_time(device_params, num_hashes) {
+    console.log("Calculating G time for num_hashes: " + num_hashes, device_params);
+    return num_hashes / device_params.g_hashes_per_ms;
+}
+
+function get_t1_pairing_time(plot_params, device_params, num_hashes) {
+    // get strength multiplier
+    var strength_multiplier = 1 << (plot_params.strength_bits - pairing_strength_start);
+    return (num_hashes * strength_multiplier) / device_params.pair_hashes_per_ms;
+}
+function get_t1_target_time(plot_params, device_params, num_hashes) {
+    // get strength multiplier
+    var strength_multiplier = 1 << (plot_params.strength_bits - pairing_strength_start);
+    return (num_hashes * strength_multiplier) / device_params.target_hashes_per_ms;
+}
+function get_t2_pairing_time(plot_params, device_params, num_hashes) {
+    return num_hashes / device_params.pair_hashes_per_ms;
+}
+function get_t2_target_time(plot_params, device_params, num_hashes) {
+    return num_hashes / device_params.target_hashes_per_ms;
+}
+function get_t3_pairing_time(plot_params, device_params, num_hashes) {
+    return num_hashes / device_params.pair_hashes_per_ms;
+}
+function get_t3_target_time(plot_params, device_params, num_hashes) {
+    return num_hashes / device_params.target_hashes_per_ms;
+}
+function get_xs_sort_time(plot_params, device_params, num_entries) {
+    if (device_params.sortXs == 0) {
+        return 0;
+    }
+    return (num_entries / device_params.sortXs);
+}
+function get_t1_sort_time(plot_params, device_params, num_entries) {
+    if (device_params.sortT1 == 0) {
+        return 0;
+    }
+    return (num_entries / device_params.sortT1);
+}
+function get_t2_sort_time(plot_params, device_params, num_entries) {
+    if (device_params.sortT2 == 0) {
+        return 0;
+    }
+    return (num_entries / device_params.sortT2);
+}
+function get_t3_sort_time(plot_params, device_params, num_entries) {
+    if (device_params.sortT3 == 0) {
+        return 0;
+    }
+    return (num_entries / device_params.sortT3);
+}
+
+function calc_validation_time(plot_params, device_params) {
+    // validation is on 128 x's, which is 64 pairs.
+    // Each x needs to do a g hash.
+    // Each pair needs to do a target hash, and pairing hash.
+    //  There are 64 T1 pairs, 32 T2 pairs, 16 T3 pairs.
+    var num_xs = 128;
+    var num_t1_pairs = 64;
+    var num_t2_pairs = 32;
+    var num_t3_pairs = 16;
+    var g_hashes_time = get_g_time(device_params, num_xs);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, num_t1_pairs);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, num_t1_pairs);
+    var t1_time = t1_target_hashes_time + t1_pairing_hashes_time;
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, num_t2_pairs);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, num_t2_pairs);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, num_t3_pairs);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, num_t3_pairs);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+    var total_time = g_hashes_time + t1_time + t2_time + t3_time;
+    var results = {
+        "G hashes": num_xs,
+        "T1 target hashes": num_t1_pairs,
+        "T1 pairing hashes": num_t1_pairs,
+        "T2 target hashes": num_t2_pairs,
+        "T2 pairing hashes": num_t2_pairs,
+        "T3 target hashes": num_t3_pairs,
+        "T3 pairing hashes": num_t3_pairs,
+        "G time (ms)": g_hashes_time,
+        "T1 time (ms)": t1_time,
+        "T2 time (ms)": t2_time,
+        "T3 time (ms)": t3_time,
+        "Total validation time (ms)": total_time
+    };
+    console.table(results);
+    return total_time;
+}
+
+function calc_plotting_time(plot_params, device_params) {
+    var num_xs_sort_entries = num_entries_per_table;
+    var num_table_sort_entries = num_entries_per_table * 4;
+    var g_hashes = num_entries_per_table;
+    var t1_target_hashes = num_entries_per_table * (1 << plot_params.t1_match_bits);
+    //var t1_pairing_hashes = num_entries_per_table; // set if t1 uses special fast match function
+    var t1_pairing_hashes = t1_target_hashes;
+    var t2_target_hashes = num_entries_per_table * (1 << plot_params.t2_match_bits);
+    var t2_pairing_hashes = t2_target_hashes;
+    var t3_target_hashes = num_entries_per_table * (1 << plot_params.t3_match_bits);
+    var t3_pairing_hashes = t3_target_hashes;
+    var g_hashes_time = get_g_time(device_params, g_hashes);
+    var xs_sort_time = get_xs_sort_time(plot_params, device_params, num_xs_sort_entries);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_sort_time = get_t1_sort_time(plot_params, device_params, num_table_sort_entries);
+    var t1_time = t1_target_hashes_time + t1_pairing_hashes_time + t1_sort_time;
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_sort_time = get_t2_sort_time(plot_params, device_params, num_table_sort_entries);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time + t2_sort_time;
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_sort_time = get_t3_sort_time(plot_params, device_params, num_table_sort_entries);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time + t3_sort_time;
+
+    var total_time = g_hashes_time + xs_sort_time + t1_time + t2_time + t3_time;
+    var results = {
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "G hashes": Math.round(g_hashes),
+        "XS sort entries": Math.round(num_xs_sort_entries),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T1 sort entries": Math.round(num_table_sort_entries),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T2 sort entries": Math.round(num_table_sort_entries),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "T3 sort entries": Math.round(num_table_sort_entries),
+        "G time (ms)": g_hashes_time,
+        "XS sort time (ms)": xs_sort_time,
+        "T1 target time (ms)": t1_target_hashes_time,
+        "T1 pairing time (ms)": t1_pairing_hashes_time,
+        "T1 sort time (ms)": t1_sort_time,
+        "T2 target time (ms)": t2_target_hashes_time,
+        "T2 pairing time (ms)": t2_pairing_hashes_time,
+        "T2 sort time (ms)": t2_sort_time,
+        "T3 target time (ms)": t3_target_hashes_time,
+        "T3 pairing time (ms)": t3_pairing_hashes_time,
+        "T3 sort time (ms)": t3_sort_time,
+        "T1 time (ms)": t1_time,
+        "T2 time (ms)": t2_time,
+        "T3 time (ms)": t3_time,
+        "Total plotting time (ms)": total_time
+    };
+
+    console.table(results);
+    return total_time;
+}
+
+function calc_pure_rental_attack(plot_params, device_params, netspace_EiB) {
+    const plotting_time = calc_plotting_time(plot_params, device_params);
+    console.log(`Calculating rental attack with plotting time: ${plotting_time.toFixed(2)} ms`);
+    var plot_size_GiB = honest_plot_size_bytes / (1024 * 1024 * 1024);
+    var netspace_GiB = netspace_EiB * 1024 * 1024 * 1024;
+    var plots_needed_for_attack = netspace_GiB / plot_size_GiB;
+    var num_supported_plots_per_challenge = 9375 / plotting_time;
+    var spoofed_plots = num_supported_plots_per_challenge * plot_params.effective_plot_id_filter;
+    var total_devices_needed_for_attack = plots_needed_for_attack / spoofed_plots;
+    var results = {
+        "Plot strength bits": plot_params.strength_bits,
+        "Plotting time (ms)": plotting_time,
+        "Effective plot ID filter": plot_params.effective_plot_id_filter,
+        "Netspace (EiB)": netspace_EiB,
+        "Netspace (GiB)": netspace_GiB,
+        "Plot size (GiB)": plot_size_GiB,
+        "Plots needed for attack": plots_needed_for_attack,
+        "Num supported plots per challenge": num_supported_plots_per_challenge,
+        "Spoofed plots per device": spoofed_plots,
+        "Total devices needed for attack": total_devices_needed_for_attack
+    };
+    console.table(results);
+    return total_devices_needed_for_attack;
+}
+
+// Reconstruction rental attack is similar to pure rental attack but we make a plotting pass and store
+// the match bits for use in plot reconstruction to get the challenge results.
+function calc_reconstruction_rental_attack(plot_params, device_params, netspace_EiB) {
+    console.log(`Calculating reconstruction rental attack`);
+
+    var data = calc_attack_strength_match_bits(plot_params, device_params);
+    console.table(data);
+
+    var reconstruction_plotting_time = data.challenge_time_ms;
+    var attack_plot_bytes = data.attacker_bits_per_entry * num_entries_per_table / 8;
+    var attack_plot_size_GiB = attack_plot_bytes / (1024 * 1024 * 1024);
+
+    var plot_size_GiB = honest_plot_size_bytes / (1024 * 1024 * 1024);
+    var netspace_GiB = netspace_EiB * 1024 * 1024 * 1024;
+    var plots_needed_for_attack = netspace_GiB / plot_size_GiB;
+    var num_supported_plots_per_challenge = 9375 * plot_params.effective_plot_id_filter / reconstruction_plotting_time;
+    var total_devices_needed_for_attack = plots_needed_for_attack / num_supported_plots_per_challenge;
+    var total_storage_needed_for_attack_PiB = plots_needed_for_attack * attack_plot_size_GiB / (1024 * 1024);
+    var results = {
+        "Plot strength bits": plot_params.strength_bits,
+        "Reconstruction plotting time (ms)": reconstruction_plotting_time,
+        "Effective plot ID filter": plot_params.effective_plot_id_filter,
+        "Netspace (EiB)": netspace_EiB,
+        "Netspace (GiB)": netspace_GiB,
+        "Attack plot size (GiB)": attack_plot_size_GiB,
+        "Plots needed for attack": plots_needed_for_attack,
+        "Num supported plots per challenge": num_supported_plots_per_challenge,
+        "Total devices needed for attack": total_devices_needed_for_attack,
+        "Total storage needed for attack (PiB)": total_storage_needed_for_attack_PiB
+    };
+    console.table(results);
+    return total_devices_needed_for_attack;
+}
+
+function calc_attack_collected_xs(challenge_sets_covered, plot_params, device_params) {
+    const challenge_data = getXsSetSizeData(challenge_sets_covered);
+    console.log(`Challenge sets covered: ${challenge_sets_covered}`);
+    console.table(challenge_data);
+    // get log2 of unique Xs and Lxs
+    const log2_unique_xs = Math.log2(challenge_data.uniqueXs);
+    console.log(`Log2 unique Xs: ${log2_unique_xs.toFixed(2)}`);
+    const bits_per_xs_sorted = k - log2_unique_xs + 1.45;
+    const bits_per_entry_xs = bits_per_xs_sorted * challenge_data.uniqueXs / challenge_data.numEntries;
+    console.log(`Bits per x sorted: ${bits_per_xs_sorted.toFixed(4)}`);
+    console.log(`Bits per entry (Xs unsorted): ${bits_per_entry_xs.toFixed(4)}`);
+    const perc_of_honest_plot_xs = bits_per_entry_xs / honest_bits_per_entry * 100;
+    console.log(`Percentage of honest plot size (Xs): ${perc_of_honest_plot_xs.toFixed(2)}%`);
+
+    var g_hashes = challenge_data.uniqueXs;
+    var t1_target_hashes = challenge_data.uniqueXs * (1 << plot_params.t1_match_bits);
+    var t1_matches = challenge_data.uniqueXs / 2;
+    var t1_pairing_hashes = t1_matches;
+
+    var t2_target_hashes = t1_matches * (1 << plot_params.t2_match_bits);
+    var t2_matches = challenge_data.uniqueXs / 4;
+    var t2_pairing_hashes = t2_matches; // TODO: not clear what this should be,, as target hashes will have less than 100% collisions. This is best-case (minimum).
+
+
+    var t3_target_hashes = t2_matches * (1 << plot_params.t3_match_bits);
+    var t3_matches = challenge_data.uniqueXs / 8;
+    var t3_pairing_hashes = t3_matches; // TODO: again, this is minimum possible.
+
+    var g_hashes_time = get_g_time(device_params, g_hashes);
+    console.log(`Calculating attack collected XS with ${g_hashes} G hashes`);
+    console.log(`G hashes time: ${g_hashes_time.toFixed(2)} ms`);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_time = g_hashes_time + t1_target_hashes_time + t1_pairing_hashes_time;
+
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+
+    var challenge_solve_time = NUM_CHALLENGE_SETS * (t1_time + t2_time + t3_time); // NUM_CHALLENGE_SETS scan sets
+    var results = {
+        "Challenge sets covered": challenge_sets_covered,
+        "T1 matches": Math.round(t1_matches),
+        "T2 matches": Math.round(t2_matches),
+        "T3 matches": Math.round(t3_matches),
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "G hashes": Math.round(g_hashes),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "G time (ms)": g_hashes_time,
+        "T1 time (ms)": t1_time,
+        "T2 time (ms)": t2_time,
+        "T3 time (ms)": t3_time,
+        [`Challenge solve time (${NUM_CHALLENGE_SETS} scan sets) (ms)`]: challenge_solve_time
+    }
+    console.table(results);
+
+
+    return calc_attack_effectiveness(plot_params, default_equipment_params, challenge_solve_time, bits_per_entry_xs);
+
+}
+
+function calc_attack_collected_lxs(challenge_sets_covered, plot_params, device_params) {
+    const challenge_data = getXsSetSizeData(challenge_sets_covered);
+    console.log(`Challenge sets covered: ${challenge_sets_covered}`);
+    console.table(challenge_data);
+    // get log2 of unique Xs and Lxs
+    const log2_unique_lxs = Math.log2(challenge_data.uniqueLxs);
+    console.log(`Log2 unique Lxs: ${log2_unique_lxs.toFixed(2)}`);
+    const bits_per_lxs_sorted = k - log2_unique_lxs + 1.45;
+    const bits_per_entry_lxs = bits_per_lxs_sorted * challenge_data.uniqueLxs / challenge_data.numEntries;
+    console.log(`Bits per entry (Lxs sorted): ${bits_per_lxs_sorted.toFixed(4)}`);
+    console.log(`Bits per entry (Lxs unsorted): ${bits_per_entry_lxs.toFixed(4)}`);
+    const perc_of_honest_plot_lxs = bits_per_entry_lxs / honest_bits_per_entry * 100;
+    console.log(`Percentage of honest plot size (Lxs): ${perc_of_honest_plot_lxs.toFixed(2)}%`);
+
+    // lx slightly different than x calculations, since we start from all g entries
+    var all_g_hashes = num_entries_per_table;
+    var lx_g_hashes = challenge_data.uniqueLxs;
+    var t1_target_hashes = challenge_data.uniqueLxs * (1 << plot_params.t1_match_bits);
+    var t1_pairing_hashes = challenge_data.uniqueLxs;
+    var t1_matches = challenge_data.uniqueLxs;
+
+    var t2_target_hashes = t1_matches * (1 << plot_params.t2_match_bits);
+    var t2_pairing_hashes = challenge_data.uniqueLxs / 2; // TODO: this is somewhere between t2_target_hashes and t2_matches. We take min for now (best case).
+    var t2_matches = challenge_data.uniqueLxs / 2;
+
+    var t3_target_hashes = t2_matches * (1 << plot_params.t3_match_bits);
+    var t3_pairing_hashes = challenge_data.numEntries; // TODO: this is somewhere between t3_target_hashes and t3_matches, we take min (best case).
+    var t3_matches = challenge_data.numEntries;
+
+    var g_hashes_time = get_g_time(device_params, all_g_hashes);
+    var lx_g_hashes_time = get_g_time(device_params, lx_g_hashes);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_time = lx_g_hashes_time + t1_target_hashes_time + t1_pairing_hashes_time;
+
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+
+    var challenge_solve_time = g_hashes_time + NUM_CHALLENGE_SETS * (t1_time + t2_time + t3_time); // NUM_CHALLENGE_SETS scan sets
+
+    var results = {
+        "Challenge sets covered": challenge_sets_covered,
+        "T1 matches": Math.round(t1_matches),
+        "T2 matches": Math.round(t2_matches),
+        "T3 matches": Math.round(t3_matches),
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "G hashes (all)": Math.round(all_g_hashes),
+        "G hashes (Lxs)": Math.round(lx_g_hashes),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "G time (ms)": g_hashes_time,
+        "T1 time (ms)": t1_time,
+        "T2 time (ms)": t2_time,
+        "T3 time (ms)": t3_time,
+        [`Challenge solve time (${NUM_CHALLENGE_SETS} scan sets) (ms)`]: challenge_solve_time
+    };
+
+    console.table(results);
+
+    return calc_attack_effectiveness(plot_params, default_equipment_params, challenge_solve_time, bits_per_entry_lxs);
+}
+
+function get_n_in_m_buckets(n, m) {
+    var pow = Math.pow(1 - (1 / m), n);
+    return m * (1 - pow);
+}
+
+// observations: T3 match bits no effect, #PF to scan leads into bit saturation for T2, beyond 4096 no effect as bits are already at zero. If you bit drop on x2 with smaller group size you get same effect -- i.e. scan 512 with 1 bit drop same result as scan 1024 with no bit drop. G function weights on lower strengths then flattens out after plot strength 7 or so. If we increased T1 match bits w/ strength then we get consistent W/TB as we up strength, but solver becomes impractical much sooner. We should be able to tune PF scan size down -- it reduces min. hdd load w/ grouping (but makes indexing trickier) and reduces security but this can be paired with min. security from other attacks.
+function calc_attack_challenge_components_bit_dropping(plot_params, device_params, drop_bits) {
+    var proof_fragments_to_scan = 1 << plot_params.scan_filter_bits;
+    console.log(`Calculating attack challenge components with pf: ${proof_fragments_to_scan}bit dropping: ${drop_bits} bits`);
+    console.table(plot_params);
+
+    var total_bit_dropped_lxs = proof_fragments_to_scan * 4;
+    console.log(`Total bit dropped Lxs: ${total_bit_dropped_lxs}`);
+
+    const possible_bit_dropped_groups = Math.pow(2, 14 - drop_bits);
+    console.log(`Possible bit dropped groups: ${possible_bit_dropped_groups}`);
+
+    const avg_unique_lx_groups = get_n_in_m_buckets(total_bit_dropped_lxs, possible_bit_dropped_groups);
+    console.log(`Avg. unique lx groups: ${avg_unique_lx_groups.toFixed(2)}`);
+
+    const log2_unique_lxs = Math.log2(avg_unique_lx_groups);
+    console.log(`Log2 unique Lxs: ${log2_unique_lxs.toFixed(2)}`);
+    const bits_per_lxs_sorted = k / 2 - drop_bits - log2_unique_lxs + 1.45;
+    const bits_per_entry_lxs = bits_per_lxs_sorted * avg_unique_lx_groups / proof_fragments_to_scan;
+    console.log(`Bits per x in Lxs sorted: ${bits_per_lxs_sorted.toFixed(4)}`);
+    console.log(`Bits per entry (Lxs sorted for # proof fragments): ${bits_per_entry_lxs.toFixed(4)}`);
+    const perc_of_honest_plot_lxs = bits_per_entry_lxs / honest_bits_per_entry * 100;
+    console.log(`Percentage of honest plot size (Lxs): ${perc_of_honest_plot_lxs.toFixed(2)}%`);
+
+    // g time is full since we always scan all g entries
+    var g_hashes = num_entries_per_table;
+    var t1_target_hashes = avg_unique_lx_groups * Math.pow(2, 14 + drop_bits) * (1 << plot_params.t1_match_bits);
+    var t1_matches = avg_unique_lx_groups * Math.pow(2, 14 + drop_bits);
+    var t1_pairing_hashes = t1_matches * (1 << plot_params.t1_match_bits); // pairing hashes inversely must filter to reach matches.
+
+    var t2_target_hashes = t1_matches * (1 << plot_params.t2_match_bits);
+    var t2_matches = (t1_matches / num_entries_per_table) * (t1_matches / num_entries_per_table) * num_entries_per_table;
+    t2_matches = get_n_in_m_buckets(t2_matches, num_entries_per_table);
+    var t2_pairing_hashes = t2_matches * (1 << plot_params.t2_match_bits); // pairing hashes inversely must filter to reach matches.
+
+    var t3_target_hashes = t2_matches * (1 << plot_params.t3_match_bits);
+    var t3_matches = (t2_matches / num_entries_per_table) * (t2_matches / num_entries_per_table) * num_entries_per_table;
+    t3_matches = get_n_in_m_buckets(t3_matches, num_entries_per_table);
+    var t3_pairing_hashes = t3_matches * (1 << plot_params.t3_match_bits); // pairing hashes inversely must filter to reach matches.
+
+    var g_hashes_time = get_g_time(device_params, g_hashes);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_time = t1_target_hashes_time + t1_pairing_hashes_time;
+
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+
+    var challenge_solve_time = g_hashes_time + NUM_CHALLENGE_SETS * (t1_time + t2_time + t3_time); // NUM_CHALLENGE_SETS scan sets
+    // NOTE that T3 entries must be then Feistel'd and filtered to within the scan PFs, though we see this as "free" work.
+
+    const results = {
+        "Proof fragments to scan": proof_fragments_to_scan,
+        "Drop bits": drop_bits,
+        "Possible bit dropped groups": possible_bit_dropped_groups,
+        "Avg. unique lx groups": avg_unique_lx_groups.toFixed(2),
+        "Bits per x in Lxs sorted": bits_per_lxs_sorted.toFixed(4),
+        "Bits per entry (Lxs sorted for # proof fragments)": bits_per_entry_lxs.toFixed(4),
+        "T1 matches": Math.round(t1_matches),
+        "T2 matches": Math.round(t2_matches),
+        "T3 matches": Math.round(t3_matches),
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "G hashes": Math.round(g_hashes),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "G time (ms)": g_hashes_time.toFixed(2),
+        "T1 time (ms)": t1_time.toFixed(2),
+        "T2 time (ms)": t2_time.toFixed(2),
+        "T3 time (ms)": t3_time.toFixed(2),
+        [`Challenge solve time (${NUM_CHALLENGE_SETS} scan sets) (ms)`]: challenge_solve_time.toFixed(2)
+    };
+
+    console.log(`Result challenge components with pf: ${proof_fragments_to_scan} bit dropping: ${drop_bits} bits for plot strength bits: ${plot_params.strength_bits} : time to solve challenge: ${challenge_solve_time.toFixed(2)} ms, bits per entry (Lxs sorted for # proof fragments): ${bits_per_entry_lxs.toFixed(4)}`);
+
+
+    console.table(results);
+
+    return calc_attack_effectiveness(plot_params, default_equipment_params, challenge_solve_time, bits_per_entry_lxs);
+
+}
+
+
+function calc_attack_proof_fragments_drop_bits(plot_params, device_params, bits_dropped) {
+    // see markdown proof_fragments.md for derivation
+    var strength_multiplier = 1 << (plot_params.strength_bits);
+    console.log(`Calculating attack with proof fragments drop bits: ${bits_dropped}, strength multiplier: ${strength_multiplier}`);
+    var total_proof_fragments_in_scan = 1 << plot_params.scan_filter_bits;
+    var total_proof_fragments_in_challenge = total_proof_fragments_in_scan * NUM_CHALLENGE_SETS; // NUM_CHALLENGE_SETS scan sets
+    console.log('Total proof fragments in challenge: ' + total_proof_fragments_in_challenge);
+    //var proof_fragments_in_chain = 60;
+    //proof_fragments_in_chain = get_n_in_m_buckets(proof_fragments_in_chain, total_proof_fragments_in_challenge);
+    var proof_fragments_in_chain = total_proof_fragments_in_challenge;
+    console.log(`Proof fragments in chaining after filtering: ${proof_fragments_in_chain.toFixed(2)}`);
+    const e = Math.E;
+    var c = 2 - 1/e;
+    var q = (1 - 1/e)*(1 - 1/e);
+    const n_pf_candidates = Math.pow(2, bits_dropped);
+    var expected_2_to_the_14_x_groups_per_pf = ((n_pf_candidates-1)*((n_pf_candidates)*c+4)/(2*(n_pf_candidates)));
+    var total_expected_2_to_the_14_x_groups = proof_fragments_in_chain * expected_2_to_the_14_x_groups_per_pf;
+    total_expected_2_to_the_14_x_groups = get_n_in_m_buckets(total_expected_2_to_the_14_x_groups, Math.pow(2,14));
+
+
+    console.log(`Expected 2^14 x groups for ${bits_dropped} bits dropped: ${total_expected_2_to_the_14_x_groups.toFixed(2)}`);
+    var expected_x12345678_validations_per_pf = (((n_pf_candidates-1)/2)*q)+((n_pf_candidates-1)/(n_pf_candidates))
+    var total_expected_x12345678_validations = proof_fragments_in_chain * expected_x12345678_validations_per_pf;
+    console.log(`Expected total x1..8 validations for ${bits_dropped} bits dropped: ${total_expected_x12345678_validations.toFixed(2)}`);
+
+    var g_hashes = num_entries_per_table;
+    var t1_target_hashes = total_expected_2_to_the_14_x_groups * Math.pow(2, 14) * (1 << plot_params.t1_match_bits);
+    var t1_pairing_hashes = total_expected_2_to_the_14_x_groups * Math.pow(2, 14);
+    var t1_matches = t1_pairing_hashes;
+
+    // for validation, we have x1..4 on L, and x5..8 on R, and we get match bits from L, so we only do one target hash on that match index for validation
+    var t2_target_hashes = t1_matches * (1 << plot_params.t2_match_bits);
+    var t2_pairing_hashes = total_expected_2_to_the_14_x_groups;
+
+    var t3_target_hashes = expected_x12345678_validations_per_pf;
+    var t3_pairing_hashes = expected_x12345678_validations_per_pf;
+
+    // no t3 work to do, since we assume we find all valid proof fragments once we've validated x1...x8.
+    var g_time = get_g_time(device_params, g_hashes);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_time = t1_target_hashes_time + t1_pairing_hashes_time;
+
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+
+    var challenge_solve_time = g_time + NUM_CHALLENGE_SETS * (t1_time + t2_time); // NUM_CHALLENGE_SETS scan sets
+
+    var bits_per_entry_proof_fragments = k - bits_dropped + 1.45;
+
+    var results = {
+        "Bits dropped": bits_dropped,
+        "Expected 2^14 x groups": total_expected_2_to_the_14_x_groups.toFixed(2),
+        "Expected x1..8 validations": total_expected_x12345678_validations.toFixed(2),
+        "Bits per entry (proof fragments)": bits_per_entry_proof_fragments.toFixed(4),
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "G hashes": Math.round(g_hashes),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "G time (ms)": g_time.toFixed(2),
+        "T1 time (ms)": t1_time.toFixed(2),
+        "T2 time (ms)": t2_time.toFixed(2),
+        "T3 time (ms)": t3_time.toFixed(2),
+        "Challenge solve time (ms)": challenge_solve_time.toFixed(2),
+    };
+    console.table(results);
+
+    return calc_attack_effectiveness(plot_params, default_equipment_params, challenge_solve_time, bits_per_entry_proof_fragments);
+
+
+}
+
+function calc_attack_strength_match_bits(plot_params, device_params) {
+    console.log(`Calculating attack strength match bits`);
+    console.table(plot_params);
+
+    const bits_per_entry = plot_params.t1_match_bits + plot_params.t2_match_bits + plot_params.t3_match_bits;
+    console.log(`Bits per entry (match bits total): ${bits_per_entry.toFixed(4)}`);
+
+    var all_g_hashes = num_entries_per_table;
+
+    var t1_target_hashes = num_entries_per_table;
+    var t1_pairing_hashes = num_entries_per_table;
+
+    var t2_target_hashes = num_entries_per_table;
+    var t2_pairing_hashes = num_entries_per_table;
+
+    var t3_target_hashes = num_entries_per_table;
+    var t3_pairing_hashes = num_entries_per_table;
+
+    var g_time = get_g_time(device_params, all_g_hashes);
+    var t1_target_hashes_time = get_t1_target_time(plot_params, device_params, t1_target_hashes);
+    var t1_pairing_hashes_time = get_t1_pairing_time(plot_params, device_params, t1_pairing_hashes);
+    var t1_time = t1_target_hashes_time + t1_pairing_hashes_time;
+
+    var t2_target_hashes_time = get_t2_target_time(plot_params, device_params, t2_target_hashes);
+    var t2_pairing_hashes_time = get_t2_pairing_time(plot_params, device_params, t2_pairing_hashes);
+    var t2_time = t2_target_hashes_time + t2_pairing_hashes_time;
+
+    var t3_target_hashes_time = get_t3_target_time(plot_params, device_params, t3_target_hashes);
+    var t3_pairing_hashes_time = get_t3_pairing_time(plot_params, device_params, t3_pairing_hashes);
+    var t3_time = t3_target_hashes_time + t3_pairing_hashes_time;
+
+    var challenge_solve_time = g_time + t1_time + t2_time + t3_time; // whole table reconstruction
+
+    var results = {
+        "T1 match bits": plot_params.t1_match_bits,
+        "T2 match bits": plot_params.t2_match_bits,
+        "T3 match bits": plot_params.t3_match_bits,
+        "Bits per entry (match bits total)": bits_per_entry.toFixed(4),
+        "G hashes": Math.round(all_g_hashes),
+        "T1 target hashes": Math.round(t1_target_hashes),
+        "T1 pairing hashes": Math.round(t1_pairing_hashes),
+        "T2 target hashes": Math.round(t2_target_hashes),
+        "T2 pairing hashes": Math.round(t2_pairing_hashes),
+        "T3 target hashes": Math.round(t3_target_hashes),
+        "T3 pairing hashes": Math.round(t3_pairing_hashes),
+        "G time (ms)": g_time.toFixed(2),
+        "T1 time (ms)": t1_time.toFixed(2),
+        "T2 time (ms)": t2_time.toFixed(2),
+        "T3 time (ms)": t3_time.toFixed(2),
+        "Challenge solve time (ms)": challenge_solve_time.toFixed(2),
+    };
+    console.table(results);
+
+    return calc_attack_effectiveness(plot_params, default_equipment_params, challenge_solve_time, bits_per_entry);
+
+}
+
+
+function get_highest_effectiveness_challenge_components_attack(plot_params, device_params) {
+    console.log(`Searching for highest effectiveness challenge components attack`);
+    console.table(plot_params);
+    var scan_filter_bits = plot_params.scan_filter_bits;
+    var best_drop_bits = -6;
+    var best_strength_bits = 2;
+    var best_effectiveness = 0.0;
+    for (var drop_bits = -8; drop_bits < 8; drop_bits++) {
+    for (var strength_bits = 2; strength_bits <= strength_cap; strength_bits++) {
+    //for (var drop_bits = 1; drop_bits < 2; drop_bits++) {
+    //    for (var strength_bits = 2; strength_bits < 3; strength_bits++) {
+            var test_plot_params = get_plot_params(plot_params.base_plot_id_filter, strength_bits);
+            test_plot_params.scan_filter_bits = scan_filter_bits;
+            var result = calc_attack_challenge_components_bit_dropping(test_plot_params, device_params, drop_bits);
+            var effectiveness = result.attacker_effectiveness;
+            console.log(`Drop bits: ${drop_bits} Strength bits: ${strength_bits} Effectiveness: ${effectiveness.toFixed(6)}`);
+            if (effectiveness > best_effectiveness) {
+                best_effectiveness = effectiveness;
+                best_drop_bits = drop_bits;
+                best_strength_bits = strength_bits;
+            }
+        }
+    }
+    console.log(`Best drop bits: ${best_drop_bits} Best strength bits: ${best_strength_bits} Best effectiveness: ${best_effectiveness.toFixed(6)}`);
+    return {
+        best_drop_bits : best_drop_bits,
+        best_strength_bits: best_strength_bits,
+        best_effectiveness: best_effectiveness
+    };
+}
+
+function get_highest_effective_collected_xs_attack(plot_params, device_params) {
+    console.log(`Searching for highest effectiveness collected xs attack`);
+    console.table(plot_params);
+    var best_challenge_sets_covered = 1;
+    var best_effectiveness = 0.0;
+    var best_strength = 2;
+    var max_challenge_sets_bits_covered = 13;
+    for (var challenge_set_bits_covered = 1; challenge_set_bits_covered <= max_challenge_sets_bits_covered; challenge_set_bits_covered++) {
+        for (var strength = 2; strength <= strength_cap; strength++) {
+            var test_plot_params = get_plot_params(plot_params.base_plot_id_filter, strength);
+            test_plot_params.scan_filter_bits = plot_params.scan_filter_bits;
+            var result = calc_attack_collected_xs(1 << challenge_set_bits_covered, test_plot_params, device_params);
+            var effectiveness = result.attacker_effectiveness;
+            console.log(`Challenge sets covered: ${1 << challenge_set_bits_covered} Strength: ${strength} Effectiveness: ${effectiveness.toFixed(6)}`);
+            if (effectiveness > best_effectiveness) {
+                best_effectiveness = effectiveness;
+                best_challenge_sets_covered = 1 << challenge_set_bits_covered;
+                best_strength = strength;
+            }
+        }
+    }
+    console.log(`Best challenge sets covered: ${best_challenge_sets_covered} Best effectiveness: ${best_effectiveness.toFixed(6)}`);
+    return {
+        best_challenge_sets_covered : best_challenge_sets_covered,
+        best_effectiveness: best_effectiveness,
+        best_strength: best_strength
+    };
+
+}
+
+function get_highest_effective_collected_lxs_attack(plot_params, device_params) {
+    console.log(`Searching for highest effectiveness collected lxs attack`);
+    console.table(plot_params);
+    var best_challenge_sets_covered = 1;
+    var best_effectiveness = 0.0;
+    var best_strength = 2;
+    var max_challenge_sets_bits_covered = 13;
+    for (var challenge_set_bits_covered = 1; challenge_set_bits_covered <= max_challenge_sets_bits_covered; challenge_set_bits_covered++) {
+        for (var strength = 2; strength <= strength_cap; strength++) {
+            var test_plot_params = get_plot_params(plot_params.base_plot_id_filter, strength);
+            test_plot_params.scan_filter_bits = plot_params.scan_filter_bits;
+            var result = calc_attack_collected_lxs(1 << challenge_set_bits_covered, test_plot_params, device_params);
+            var effectiveness = result.attacker_effectiveness;
+            console.log(`Challenge sets covered: ${1 << challenge_set_bits_covered} Strength: ${strength} Effectiveness: ${effectiveness.toFixed(6)}`);
+            if (effectiveness > best_effectiveness) {
+                best_effectiveness = effectiveness;
+                best_challenge_sets_covered = 1 << challenge_set_bits_covered;
+                best_strength = strength;
+            }
+        }
+    }
+    console.log(`Best challenge sets covered: ${best_challenge_sets_covered} Best effectiveness: ${best_effectiveness.toFixed(6)}`);
+    return {
+        best_challenge_sets_covered : best_challenge_sets_covered,
+        best_effectiveness: best_effectiveness,
+        best_strength: best_strength
+    };
+
+}
+
+function get_highest_effective_proof_fragments_drop_bits_attack(plot_params, device_params) {
+    console.log(`Searching for highest effectiveness proof fragments drop bits attack`);
+    console.table(plot_params);
+    var best_bits_dropped = -6;
+    var best_effectiveness = 0.0;
+    for (var bits_dropped = -8; bits_dropped < 8; bits_dropped++) {
+        for (var strength = 2; strength <= strength_cap; strength++) {
+            var test_plot_params = get_plot_params(plot_params.base_plot_id_filter, strength);
+            test_plot_params.scan_filter_bits = plot_params.scan_filter_bits;
+            var result = calc_attack_proof_fragments_drop_bits(test_plot_params, device_params, bits_dropped);
+            var effectiveness = result.attacker_effectiveness;
+            console.log(`Bits dropped: ${bits_dropped} Strength bits: ${strength} Effectiveness: ${effectiveness.toFixed(6)}`);
+            if (effectiveness > best_effectiveness) {
+                best_effectiveness = effectiveness;
+                best_bits_dropped = bits_dropped;
+                best_strength = strength;
+            }
+        }
+    }
+    console.log(`Best bits dropped: ${best_bits_dropped} Best strength bits: ${best_strength} Best effectiveness: ${best_effectiveness.toFixed(6)}`);
+    return {
+        best_bits_dropped : best_bits_dropped,
+        best_strength: best_strength,
+        best_effectiveness: best_effectiveness
+    };
+}
+
+function get_highest_effective_strength_match_bits_attack(plot_params, device_params) {
+    console.log(`Searching for highest effectiveness strength match bits attack`);
+    console.table(plot_params);
+    var best_strength = 2;
+    var best_effectiveness = 0.0;
+    for (var strength = 2; strength <= strength_cap; strength++) {
+        var test_plot_params = get_plot_params(plot_params.base_plot_id_filter, strength);
+        test_plot_params.scan_filter_bits = plot_params.scan_filter_bits;
+        var result = calc_attack_strength_match_bits(test_plot_params, device_params);
+        var effectiveness = result.attacker_effectiveness;
+        console.log(`Strength bits: ${strength} Effectiveness: ${effectiveness.toFixed(6)}`);
+        if (effectiveness > best_effectiveness) {
+            best_effectiveness = effectiveness;
+            best_strength = strength;
+        }
+    }
+    console.log(`Best strength bits: ${best_strength} Best effectiveness: ${best_effectiveness.toFixed(6)}`);
+    return {
+        best_strength: best_strength,
+        best_effectiveness: best_effectiveness
+    };
+}

--- a/src/tools/postune/proof_fragments.md
+++ b/src/tools/postune/proof_fragments.md
@@ -1,0 +1,108 @@
+# Expected Number of Set Checks to Recover All 60 Valid Proof Fragments
+
+We start with 60 valid proof fragments (each originally 56 bits). We apply a bit drop of N bits where N ∈ {1,…,16}.
+
+## Candidates per proof
+Dropping N bits produces M = 2^N candidate fragments per original proof. Exactly one of the M candidates is the true valid fragment; the other M−1 are invalid. There are 60 independent buckets (one per original proof), each with M candidates. We process each bucket independently and stop as soon as the valid candidate is known (if M−1 candidates have been rejected, the last is valid by elimination).
+
+## Candidate checking procedure
+Each candidate carries two internal filter sets: Set A and Set B.
+- Check Set A.
+- If Set A passes, check Set B.
+- If both pass, a final full proof check is done (not counted here).
+
+Assumptions:
+- For an invalid candidate, each set (A or B) fails independently with probability 1/e.
+- For a valid candidate, both sets always pass.
+- We count only set checks (A and B), not the final full proof check.
+
+## Expected cost per candidate
+For an invalid candidate:
+- With probability 1/e: Set A fails → 1 set checked.
+- With probability 1−1/e: Set A passes, then Set B → 2 sets checked.
+
+Let c be the expected sets for an invalid candidate:
+c = 1·(1/e) + 2·(1 − 1/e) = 2 − 1/e ≈ 1.6321.
+
+For a valid candidate, if tested it always costs 2 set checks; however, it may not be tested when it is the last remaining candidate.
+
+## Number of candidates tested in a bucket
+Let M = 2^N and the valid candidate’s random position K ∈ {1,…,M} be uniform. We test in order until the valid is found:
+- If K < M: test K candidates (including the valid).
+- If K = M: test M−1 candidates (last one deduced).
+
+Expected tested candidates:
+E[T] = (M + 1)/2 − 1/M.
+
+Expected invalid candidates tested:
+E[invalid tested] = (M − 1)/2.
+
+## Expected set checks per bucket
+Invalid tested candidates cost c sets on average; the valid candidate is tested with probability (M − 1)/M, costing 2 sets when tested. Therefore:
+E[sets per bucket] = c·(M − 1)/2 + 2·(M − 1)/M.
+
+Equivalently:
+E[sets per bucket] = ((M − 1)·(c·M + 4)) / (2·M),
+where M = 2^N and c = 2 − 1/e.
+
+## Total expected set checks for 60 proofs
+E[total sets for 60 proofs] = 60 · ((M − 1)·(c·M + 4)) / (2·M).
+
+## Concrete values for N = 1…16
+
+Below is a table of the expected total number of set checks needed to recover all 60 valid proof fragments, for different bit-drop amounts \(N\).
+
+- \(N\): number of bits dropped
+- \(2^N\): candidates per original proof
+- “Sets per proof” = expected set checks per bucket
+- “Total sets” = expected set checks across all 60 proofs
+
+(All values rounded to the nearest integer.)
+
+| N | Candidates per proof ( \(2^N\) ) | Expected sets per proof | Expected sets total (60 proofs) | Expected validations per proof | Expected validations total (60 proofs) |
+|---|----------------------------------:|------------------------:|--------------------------------:|-------------------------------:|---------------------------------------:|
+| 1  | 2        | 2     | 109      | 1    | 60       |
+| 2  | 4        | 4     | 237      | 1    | 81       |
+| 3  | 8        | 7     | 448      | 2    | 136      |
+| 4  | 16       | 14    | 847      | 4    | 236      |
+| 5  | 32       | 27    | 1,634    | 7    | 430      |
+| 6  | 64       | 53    | 3,203    | 14   | 814      |
+| 7  | 128      | 106   | 6,337    | 26   | 1,582    |
+| 8  | 256      | 210   | 12,605   | 52   | 3,118    |
+| 9  | 512      | 419   | 25,140   | 103  | 6,185    |
+| 10 | 1,024    | 837   | 50,210   | 205  | 12,323   |
+| 11 | 2,048    | 1,672 | 100,348  | 410  | 24,598   |
+| 12 | 4,096    | 3,344 | 200,626  | 819  | 49,148   |
+| 13 | 8,192    | 6,686 | 401,181  | 1,637| 98,248   |
+| 14 | 16,384   | 13,372| 802,291  | 3,274| 196,447  |
+| 15 | 32,768   | 26,742| 1,604,511| 6,547| 392,847  |
+| 16 | 65,536   | 53,483| 3,208,951| 13,094| 785,646 |
+
+## Expected validation checks (final proof checks)
+
+We count how many times a candidate reaches the final validation check (after both sets pass).
+
+Let:
+- \(N\) = bit-drop amount, \(M = 2^N\) candidates per proof (bucket).
+- There are 60 buckets.
+- For invalid candidates, each set passes with probability \(1 - 1/e\), so both pass with probability:
+  \[
+  q = (1 - 1/e)^2 \approx 0.3995764.
+  \]
+- The valid candidate, if tested, always reaches validation.
+- We stop as soon as the valid candidate is known; the last candidate is not tested.
+
+Per bucket:
+- Expected invalid candidates tested: \((M - 1)/2\).
+- Expected validations from invalids: \((M - 1)/2 \cdot q\).
+- Valid candidate is tested with probability \((M - 1)/M\), contributing \( (M - 1)/M \) validations.
+
+Therefore:
+\[
+\mathbb{E}[\text{validations per proof}] = \frac{M - 1}{2}\,q + \frac{M - 1}{M}, \quad M = 2^N,\; q = (1 - 1/e)^2.
+\]
+
+For all 60 proofs:
+\[
+\mathbb{E}[\text{total validations}] = 60 \left( \frac{M - 1}{2}\,(1 - 1/e)^2 + \frac{M - 1}{M} \right), \quad M = 2^N.
+\]


### PR DESCRIPTION
Standalone in-browser analytics tool for tuning PoS plot parameters (strength, match bits, scan filter) and evaluating attacker effectiveness across the collected-xs, collected-Lxs, challenge component bit-dropping, proof-fragment bit-dropping, strength match-bits, and pure/reconstruction rental attacks.

Lives entirely under src/tools/postune/ as static HTML + JS, with proof_fragments.md documenting the math behind the bit-dropping calculations.